### PR TITLE
Fix for Version checking crash and change version URL to point to repository

### DIFF
--- a/src/main/java/biomesoplenty/handlers/TickHandlerClient.java
+++ b/src/main/java/biomesoplenty/handlers/TickHandlerClient.java
@@ -40,7 +40,7 @@ public class TickHandlerClient implements ITickHandler
 		    player.sendChatToPlayer(updateMessage);
 		}
 
-		if (Version.needsUpdateNoticeAndMarkAsSeen()) 
+		if (Version.needsUpdateNoticeAndMarkAsSeen() && Version.getRecommendedVersion() != null) 
 		{
 		    ChatMessageComponent updateMessage = new ChatMessageComponent();
 		    updateMessage.setColor(EnumChatFormatting.RED);    

--- a/src/main/java/biomesoplenty/lib/Reference.java
+++ b/src/main/java/biomesoplenty/lib/Reference.java
@@ -26,6 +26,6 @@ public class Reference
     }
     
     public static final String VERSION;
-    public static final String REMOTE_VERSION_FILE = "https://raw.github.com/BiomesOPlenty/BiomesOPlenty/master/version.txt";
-    public static final String REMOTE_CHANGELOG_ROOT = "https://raw.github.com/BiomesOPlenty/BiomesOPlenty/master/changelog/";
+    public static final String REMOTE_VERSION_FILE = "https://raw.github.com/Glitchfiend/BiomesOPlenty/master/version.txt";
+    public static final String REMOTE_CHANGELOG_ROOT = "https://raw.github.com/Glitchfiend/BiomesOPlenty/master/changelog/";
 }


### PR DESCRIPTION
A fix for the crash that some people encountered earlier today, as well as changing the version url to point to the new git repository. Github wasn't redirecting some people to the new repository, which was causing crashes to occur from github sending the request to an error page and the correct version not getting set.
