### PR TITLE
Fixes flowers and mushrooms cannot grow on BlockBOPGrass

### DIFF
--- a/src/main/java/biomesoplenty/common/blocks/BlockBOPFlower.java
+++ b/src/main/java/biomesoplenty/common/blocks/BlockBOPFlower.java
@@ -235,7 +235,7 @@ public class BlockBOPFlower extends BOPBlockWorldDecor
 			return block == this;
 
 		default:
-			return block == Blocks.grass || block == Blocks.dirt || block == Blocks.farmland || block == BOPBlockHelper.get("longGrass") || block == BOPBlockHelper.get("overgrownNetherrack");
+			return block == Blocks.grass || block == Blocks.dirt || block == Blocks.farmland || block == BOPBlockHelper.get("longGrass") || block == BOPBlockHelper.get("overgrownNetherrack") || block == BOPBlockHelper.get("grass");
 		}
 	}
 	@Override

--- a/src/main/java/biomesoplenty/common/blocks/BlockBOPFlower2.java
+++ b/src/main/java/biomesoplenty/common/blocks/BlockBOPFlower2.java
@@ -197,7 +197,7 @@ public class BlockBOPFlower2 extends BOPBlockWorldDecor
 			return block == Blocks.grass || block == Blocks.dirt || block == Blocks.farmland || block == BOPBlockHelper.get("longGrass") || block == BOPBlockHelper.get("overgrownNetherrack") || block == BOPBlockHelper.get("originGrass");
 
 		default:
-			return block == Blocks.grass || block == Blocks.dirt || block == Blocks.farmland || block == BOPBlockHelper.get("longGrass") || block == BOPBlockHelper.get("overgrownNetherrack");
+			return block == Blocks.grass || block == Blocks.dirt || block == Blocks.farmland || block == BOPBlockHelper.get("longGrass") || block == BOPBlockHelper.get("overgrownNetherrack") || block == BOPBlockHelper.get("grass");
 		}
 	}
 

--- a/src/main/java/biomesoplenty/common/blocks/BlockBOPMushroom.java
+++ b/src/main/java/biomesoplenty/common/blocks/BlockBOPMushroom.java
@@ -167,7 +167,7 @@ public class BlockBOPMushroom extends BlockBush
 			return block == Blocks.grass || block == Blocks.dirt || block == Blocks.mycelium || block == Blocks.stone || block == Blocks.netherrack || block == BOPBlockHelper.get("overgrownNetherrack");
 
 		default:
-			return block == Blocks.grass || block == Blocks.dirt || block == Blocks.mycelium || block == BOPBlockHelper.get("overgrownNetherrack");
+			return block == Blocks.grass || block == Blocks.dirt || block == Blocks.mycelium || block == BOPBlockHelper.get("overgrownNetherrack") || block == BOPBlockHelper.get("grass");
 		}
 	}
 


### PR DESCRIPTION
Fix flowers and mushrooms so can be placed on BlockBOPGrass blocks.

Required to make PromisedLand standalone mod work.
