### PR TITLE
Initializing biomesToSpawnIn

### DIFF
--- a/src/main/java/biomesoplenty/common/world/WorldChunkManagerBOPHell.java
+++ b/src/main/java/biomesoplenty/common/world/WorldChunkManagerBOPHell.java
@@ -26,6 +26,7 @@ public class WorldChunkManagerBOPHell extends WorldChunkManager
 	protected WorldChunkManagerBOPHell()
 	{
 		biomeCache = new BiomeCacheHell(this);
+		biomesToSpawnIn = new ArrayList<BiomeGenBase>();
 	}
 
 	public WorldChunkManagerBOPHell(long par1, WorldType par3WorldType)


### PR DESCRIPTION
Prevents an NPE when the Spawn Point is moved to the nether.
