### PR TITLE
Harvestcraft Turnip seeds

### DIFF
--- a/src/main/java/biomesoplenty/common/blocks/BlockBOPFoliage.java
+++ b/src/main/java/biomesoplenty/common/blocks/BlockBOPFoliage.java
@@ -45,6 +45,8 @@ public class BlockBOPFoliage extends BOPBlockWorldDecor implements IShearable
 
     private static final int FLAXTOP = 6;
     private static final int FLAXBOTTOM = 3;
+    
+    public static ItemStack turnipSeedStack = new ItemStack(BOPCItems.turnipSeeds, 1);
 
 	public BlockBOPFoliage()
 	{
@@ -132,7 +134,7 @@ public class BlockBOPFoliage extends BOPBlockWorldDecor implements IShearable
 
 			if (world.rand.nextInt(2) == 0) 
 			{
-				ret.add(new ItemStack(BOPCItems.turnipSeeds, 1));
+				ret.add(turnipSeedStack.copy());
 			}
 			break;
 			

--- a/src/main/java/biomesoplenty/common/eventhandler/BOPEventHandlers.java
+++ b/src/main/java/biomesoplenty/common/eventhandler/BOPEventHandlers.java
@@ -12,6 +12,7 @@ import biomesoplenty.common.eventhandler.entity.SlimeSpawnEventHandler;
 import biomesoplenty.common.eventhandler.entity.TemptEventHandler;
 import biomesoplenty.common.eventhandler.misc.BonemealEventHandler;
 import biomesoplenty.common.eventhandler.misc.BucketEventHandler;
+import biomesoplenty.common.eventhandler.misc.OreDictionaryEventHandler;
 import biomesoplenty.common.eventhandler.potions.PotionParalysisEventHandler;
 import biomesoplenty.common.eventhandler.potions.PotionPossessionEventHandler;
 import biomesoplenty.common.eventhandler.world.BiomeSizeEventHandler;
@@ -69,6 +70,7 @@ public class BOPEventHandlers
 	{
 		MinecraftForge.EVENT_BUS.register(new BonemealEventHandler());
 		MinecraftForge.EVENT_BUS.register(new BucketEventHandler());
+		MinecraftForge.EVENT_BUS.register(new OreDictionaryEventHandler());
 	}
 	
 	private static void registerClientEventHandlers()

--- a/src/main/java/biomesoplenty/common/eventhandler/misc/OreDictionaryEventHandler.java
+++ b/src/main/java/biomesoplenty/common/eventhandler/misc/OreDictionaryEventHandler.java
@@ -1,0 +1,18 @@
+package biomesoplenty.common.eventhandler.misc;
+
+import biomesoplenty.api.content.BOPCItems;
+import biomesoplenty.common.blocks.BlockBOPFoliage;
+import net.minecraftforge.oredict.OreDictionary.OreRegisterEvent;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+public class OreDictionaryEventHandler {
+	private static final String TurnipSeedEntry = "seedTurnip";
+		
+	@SubscribeEvent
+	public void OreRegister(OreRegisterEvent event)
+	{
+		if(event.Name == TurnipSeedEntry && event.Ore.getItem() != BOPCItems.turnipSeeds)
+		{
+			BlockBOPFoliage.turnipSeedStack = event.Ore.copy();
+		}
+	}
+}


### PR DESCRIPTION
Made it so that if harvestcraft turnip seeds (or anything else using the same ore dictionary entry) will be used in place of the default turnip seeds. Yay turnip soup!
