### PR TITLE
Issue #369 add Mahogany logs as a logWood resource

### DIFF
--- a/src/main/java/biomesoplenty/common/core/BOPCrafting.java
+++ b/src/main/java/biomesoplenty/common/core/BOPCrafting.java
@@ -335,10 +335,7 @@ public class BOPCrafting
 			OreDictionary.registerOre("logWood", new ItemStack(BOPCBlocks.logs1, 1, i));
 			OreDictionary.registerOre("logWood", new ItemStack(BOPCBlocks.logs2, 1, i));
 			OreDictionary.registerOre("logWood", new ItemStack(BOPCBlocks.logs3, 1, i));
-			if (i < 3)
-			{
-				OreDictionary.registerOre("logWood", new ItemStack(BOPCBlocks.logs4, 1, i));
-			}
+			OreDictionary.registerOre("logWood", new ItemStack(BOPCBlocks.logs4, 1, i));
 		}
 
 		OreDictionary.registerOre("slabWood", new ItemStack(BOPCBlocks.woodenSingleSlab1, 1, OreDictionary.WILDCARD_VALUE));


### PR DESCRIPTION
In the changed code below, there is an unneeded if statement causing the Mahogany wood problem in issue #369.  I'm not sure about the flowerStem component of that issue, and I'm not attempting to address it here.
i == 3 is a Mohagony log.  Due to this bug it is currently not registered as logWood, and with this fix it is.