### PR TITLE
Added new configuration variables that can adjust the height of biomes during worldgen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ eclipse/*
 docs/*
 conf/*
 bin/*
+build/*
+.gradle
 
 src/minecraft/cpw/*
 src/minecraft/net/minecraft/*

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenAlps.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenAlps.java
@@ -6,10 +6,13 @@ import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.world.World;
 import biomesoplenty.common.biome.BOPOverworldBiome;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenAlps extends BOPOverworldBiome
 {
-	private static final Height biomeHeight = new Height(8.0F, 0.025F);
+	//private static final Height biomeHeight = new Height(8.0F, 0.025F);
+	private static final Height biomeHeight = new Height(8.0F*BOPConfigurationTerrainGen.heightrootmod, 0.025F*BOPConfigurationTerrainGen.heightvarmod);
 	
 	public BiomeGenAlps(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenAlps.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenAlps.java
@@ -7,12 +7,12 @@ import net.minecraft.init.Blocks;
 import net.minecraft.world.World;
 import biomesoplenty.common.biome.BOPOverworldBiome;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenAlps extends BOPOverworldBiome
 {
 	//private static final Height biomeHeight = new Height(8.0F, 0.025F);
-	private static final Height biomeHeight = new Height(8.0F*BOPConfigurationTerrainGen.heightrootmod, 0.025F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(8.0F*BOPConfigurationTerrainGen.heightrootmod, 0.025F*BOPConfigurationTerrainGen.heightVarMod);
 	
 	public BiomeGenAlps(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenArctic.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenArctic.java
@@ -8,10 +8,13 @@ import net.minecraft.world.World;
 import biomesoplenty.api.content.BOPCBlocks;
 import biomesoplenty.client.fog.IBiomeFog;
 import biomesoplenty.common.biome.BOPOverworldBiome;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenArctic extends BOPOverworldBiome implements IBiomeFog
 {
-	private static final Height biomeHeight = new Height(0F, 0F);
+	//private static final Height biomeHeight = new Height(0F, 0F);
+	private static final Height biomeHeight = new Height(0F*BOPConfigurationTerrainGen.heightrootmod, 0F*BOPConfigurationTerrainGen.heightvarmod);
 	
 	public BiomeGenArctic(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenArctic.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenArctic.java
@@ -9,12 +9,12 @@ import biomesoplenty.api.content.BOPCBlocks;
 import biomesoplenty.client.fog.IBiomeFog;
 import biomesoplenty.common.biome.BOPOverworldBiome;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenArctic extends BOPOverworldBiome implements IBiomeFog
 {
 	//private static final Height biomeHeight = new Height(0F, 0F);
-	private static final Height biomeHeight = new Height(0F*BOPConfigurationTerrainGen.heightrootmod, 0F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(0F*BOPConfigurationTerrainGen.heightrootmod, 0F*BOPConfigurationTerrainGen.heightVarMod);
 	
 	public BiomeGenArctic(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenBambooForest.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenBambooForest.java
@@ -14,10 +14,13 @@ import biomesoplenty.client.fog.IBiomeFog;
 import biomesoplenty.common.biome.BOPOverworldBiome;
 import biomesoplenty.common.world.features.WorldGenBOPDoubleFlora;
 import biomesoplenty.common.world.features.trees.WorldGenBulbTree;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenBambooForest extends BOPOverworldBiome implements IBiomeFog
 {
-	private static final Height biomeHeight = new Height(0.1F, 0.3F);
+	//private static final Height biomeHeight = new Height(0.1F, 0.3F);
+	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.3F*BOPConfigurationTerrainGen.heightvarmod);
 	
 	public BiomeGenBambooForest(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenBambooForest.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenBambooForest.java
@@ -15,12 +15,12 @@ import biomesoplenty.common.biome.BOPOverworldBiome;
 import biomesoplenty.common.world.features.WorldGenBOPDoubleFlora;
 import biomesoplenty.common.world.features.trees.WorldGenBulbTree;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenBambooForest extends BOPOverworldBiome implements IBiomeFog
 {
 	//private static final Height biomeHeight = new Height(0.1F, 0.3F);
-	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.3F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.3F*BOPConfigurationTerrainGen.heightVarMod);
 	
 	public BiomeGenBambooForest(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenBayou.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenBayou.java
@@ -16,10 +16,13 @@ import biomesoplenty.common.world.features.WorldGenMoss;
 import biomesoplenty.common.world.features.trees.WorldGenBayou1;
 import biomesoplenty.common.world.features.trees.WorldGenBayou2;
 import biomesoplenty.common.world.features.trees.WorldGenBayou3;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenBayou extends BOPOverworldBiome implements IBiomeFog
 {
-    private static final Height biomeHeight = new Height(-0.1F, 0.1F);
+    //private static final Height biomeHeight = new Height(-0.1F, 0.1F);
+	private static final Height biomeHeight = new Height(-0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightvarmod);
 
 	public BiomeGenBayou(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenBayou.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenBayou.java
@@ -17,12 +17,12 @@ import biomesoplenty.common.world.features.trees.WorldGenBayou1;
 import biomesoplenty.common.world.features.trees.WorldGenBayou2;
 import biomesoplenty.common.world.features.trees.WorldGenBayou3;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenBayou extends BOPOverworldBiome implements IBiomeFog
 {
     //private static final Height biomeHeight = new Height(-0.1F, 0.1F);
-	private static final Height biomeHeight = new Height(-0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(-0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightVarMod);
 
 	public BiomeGenBayou(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenBog.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenBog.java
@@ -15,12 +15,12 @@ import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBogBush;
 import biomesoplenty.common.world.features.trees.WorldGenCypress;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenBog extends BOPOverworldBiome
 {
     //private static final Height biomeHeight = new Height(0.1F, 0.2F);
- 	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.2F*BOPConfigurationTerrainGen.heightvarmod);
+ 	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.2F*BOPConfigurationTerrainGen.heightVarMod);
    
     public BiomeGenBog(int id)
     {

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenBog.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenBog.java
@@ -14,11 +14,14 @@ import biomesoplenty.common.biome.BOPOverworldBiome;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBogBush;
 import biomesoplenty.common.world.features.trees.WorldGenCypress;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenBog extends BOPOverworldBiome
 {
-    private static final Height biomeHeight = new Height(0.1F, 0.2F);
-    
+    //private static final Height biomeHeight = new Height(0.1F, 0.2F);
+ 	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.2F*BOPConfigurationTerrainGen.heightvarmod);
+   
     public BiomeGenBog(int id)
     {
         super(id);

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenBorealForest.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenBorealForest.java
@@ -16,10 +16,13 @@ import biomesoplenty.common.world.features.WorldGenBOPDoubleFlora;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBOPTaiga2;
 import biomesoplenty.common.world.features.trees.WorldGenOriginalTree;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenBorealForest extends BOPOverworldBiome
 {
-	private static final Height biomeHeight = new Height(0.2F, 0.4F);
+	//private static final Height biomeHeight = new Height(0.2F, 0.4F);
+	private static final Height biomeHeight = new Height(0.2F*BOPConfigurationTerrainGen.heightrootmod, 0.4F*BOPConfigurationTerrainGen.heightvarmod);
 	
 	public BiomeGenBorealForest(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenBorealForest.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenBorealForest.java
@@ -17,12 +17,12 @@ import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBOPTaiga2;
 import biomesoplenty.common.world.features.trees.WorldGenOriginalTree;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenBorealForest extends BOPOverworldBiome
 {
 	//private static final Height biomeHeight = new Height(0.2F, 0.4F);
-	private static final Height biomeHeight = new Height(0.2F*BOPConfigurationTerrainGen.heightrootmod, 0.4F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(0.2F*BOPConfigurationTerrainGen.heightrootmod, 0.4F*BOPConfigurationTerrainGen.heightVarMod);
 	
 	public BiomeGenBorealForest(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenBrushland.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenBrushland.java
@@ -15,12 +15,12 @@ import biomesoplenty.common.world.features.trees.WorldGenBrush1;
 import biomesoplenty.common.world.features.trees.WorldGenBrush2;
 import biomesoplenty.common.world.features.trees.WorldGenMiniShrub;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenBrushland extends BOPOverworldBiome
 {
 	//private static final Height biomeHeight = new Height(0.1F, 0.2F);
-	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.2F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.2F*BOPConfigurationTerrainGen.heightVarMod);
 	
 	public BiomeGenBrushland(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenBrushland.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenBrushland.java
@@ -14,10 +14,13 @@ import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBrush1;
 import biomesoplenty.common.world.features.trees.WorldGenBrush2;
 import biomesoplenty.common.world.features.trees.WorldGenMiniShrub;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenBrushland extends BOPOverworldBiome
 {
-	private static final Height biomeHeight = new Height(0.1F, 0.2F);
+	//private static final Height biomeHeight = new Height(0.1F, 0.2F);
+	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.2F*BOPConfigurationTerrainGen.heightvarmod);
 	
 	public BiomeGenBrushland(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenCanyon.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenCanyon.java
@@ -13,12 +13,12 @@ import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBOPShrub;
 import biomesoplenty.common.world.features.trees.WorldGenPineTree;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenCanyon extends BOPOverworldBiome
 {
 	//private static final Height biomeHeight = new Height(5.0F, 0.025F);
-	private static final Height biomeHeight = new Height(5.0F*BOPConfigurationTerrainGen.heightrootmod, 0.025F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(5.0F*BOPConfigurationTerrainGen.heightrootmod, 0.025F*BOPConfigurationTerrainGen.heightVarMod);
 
 	public BiomeGenCanyon(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenCanyon.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenCanyon.java
@@ -12,10 +12,13 @@ import biomesoplenty.common.biome.BOPOverworldBiome;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBOPShrub;
 import biomesoplenty.common.world.features.trees.WorldGenPineTree;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenCanyon extends BOPOverworldBiome
 {
-	private static final Height biomeHeight = new Height(5.0F, 0.025F);
+	//private static final Height biomeHeight = new Height(5.0F, 0.025F);
+	private static final Height biomeHeight = new Height(5.0F*BOPConfigurationTerrainGen.heightrootmod, 0.025F*BOPConfigurationTerrainGen.heightvarmod);
 
 	public BiomeGenCanyon(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenChaparral.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenChaparral.java
@@ -17,12 +17,12 @@ import biomesoplenty.common.world.features.trees.WorldGenBOPShrub;
 import biomesoplenty.common.world.features.trees.WorldGenChaparral3;
 import biomesoplenty.common.world.features.trees.WorldGenMiniShrub;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenChaparral extends BOPOverworldBiome
 {
     //private static final Height biomeHeight = new Height(0.2F, 0.3F);
-	private static final Height biomeHeight = new Height(0.2F*BOPConfigurationTerrainGen.heightrootmod, 0.3F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(0.2F*BOPConfigurationTerrainGen.heightrootmod, 0.3F*BOPConfigurationTerrainGen.heightVarMod);
 
     public BiomeGenChaparral(int id)
     {

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenChaparral.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenChaparral.java
@@ -16,10 +16,13 @@ import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBOPShrub;
 import biomesoplenty.common.world.features.trees.WorldGenChaparral3;
 import biomesoplenty.common.world.features.trees.WorldGenMiniShrub;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenChaparral extends BOPOverworldBiome
 {
-    private static final Height biomeHeight = new Height(0.2F, 0.3F);
+    //private static final Height biomeHeight = new Height(0.2F, 0.3F);
+	private static final Height biomeHeight = new Height(0.2F*BOPConfigurationTerrainGen.heightrootmod, 0.3F*BOPConfigurationTerrainGen.heightvarmod);
 
     public BiomeGenChaparral(int id)
     {

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenCherryBlossomGrove.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenCherryBlossomGrove.java
@@ -14,12 +14,12 @@ import biomesoplenty.common.world.features.WorldGenBOPFlora;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBOPBigTree;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenCherryBlossomGrove extends BOPOverworldBiome
 {
 	//private static final Height biomeHeight = new Height(0.1F, 0.2F);
-	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.2F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.2F*BOPConfigurationTerrainGen.heightVarMod);
 
 	public BiomeGenCherryBlossomGrove(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenCherryBlossomGrove.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenCherryBlossomGrove.java
@@ -13,10 +13,13 @@ import biomesoplenty.common.world.features.WorldGenBOPDoubleFlora;
 import biomesoplenty.common.world.features.WorldGenBOPFlora;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBOPBigTree;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenCherryBlossomGrove extends BOPOverworldBiome
 {
-	private static final Height biomeHeight = new Height(0.1F, 0.2F);
+	//private static final Height biomeHeight = new Height(0.1F, 0.2F);
+	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.2F*BOPConfigurationTerrainGen.heightvarmod);
 
 	public BiomeGenCherryBlossomGrove(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenConiferousForest.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenConiferousForest.java
@@ -17,12 +17,12 @@ import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBOPTaiga2;
 import biomesoplenty.common.world.features.trees.WorldGenBOPTaiga3;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenConiferousForest extends BOPOverworldBiome
 {
     //private static final Height biomeHeight = new Height(0.1F, 0.3F);
-	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.3F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.3F*BOPConfigurationTerrainGen.heightVarMod);
 
 	public BiomeGenConiferousForest(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenConiferousForest.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenConiferousForest.java
@@ -16,10 +16,13 @@ import biomesoplenty.common.world.features.WorldGenBOPFlora;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBOPTaiga2;
 import biomesoplenty.common.world.features.trees.WorldGenBOPTaiga3;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenConiferousForest extends BOPOverworldBiome
 {
-    private static final Height biomeHeight = new Height(0.1F, 0.3F);
+    //private static final Height biomeHeight = new Height(0.1F, 0.3F);
+	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.3F*BOPConfigurationTerrainGen.heightvarmod);
 
 	public BiomeGenConiferousForest(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenConiferousForestSnow.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenConiferousForestSnow.java
@@ -14,11 +14,14 @@ import biomesoplenty.common.world.features.WorldGenBOPFlora;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBOPTaiga2;
 import biomesoplenty.common.world.features.trees.WorldGenBOPTaiga3;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenConiferousForestSnow extends BOPOverworldBiome
 {
-    private static final Height biomeHeight = new Height(0.1F, 0.3F);
-    
+    //private static final Height biomeHeight = new Height(0.1F, 0.3F);
+  	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.3F*BOPConfigurationTerrainGen.heightvarmod);
+  
     public BiomeGenConiferousForestSnow(int id)
     {
         super(id);

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenConiferousForestSnow.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenConiferousForestSnow.java
@@ -15,12 +15,12 @@ import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBOPTaiga2;
 import biomesoplenty.common.world.features.trees.WorldGenBOPTaiga3;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenConiferousForestSnow extends BOPOverworldBiome
 {
     //private static final Height biomeHeight = new Height(0.1F, 0.3F);
-  	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.3F*BOPConfigurationTerrainGen.heightvarmod);
+  	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.3F*BOPConfigurationTerrainGen.heightVarMod);
   
     public BiomeGenConiferousForestSnow(int id)
     {

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenCrag.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenCrag.java
@@ -10,12 +10,12 @@ import biomesoplenty.client.fog.IBiomeFog;
 import biomesoplenty.common.biome.BOPOverworldBiome;
 import biomesoplenty.common.configuration.BOPConfigurationMisc;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenCrag extends BOPOverworldBiome implements IBiomeFog
 {
 	//private static final Height biomeHeight = new Height(2.0F, 3.0F);
-	private static final Height biomeHeight = new Height(2.0F*BOPConfigurationTerrainGen.heightrootmod, 3.0F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(2.0F*BOPConfigurationTerrainGen.heightrootmod, 3.0F*BOPConfigurationTerrainGen.heightVarMod);
 	
 	public BiomeGenCrag(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenCrag.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenCrag.java
@@ -9,10 +9,13 @@ import biomesoplenty.api.content.BOPCBlocks;
 import biomesoplenty.client.fog.IBiomeFog;
 import biomesoplenty.common.biome.BOPOverworldBiome;
 import biomesoplenty.common.configuration.BOPConfigurationMisc;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenCrag extends BOPOverworldBiome implements IBiomeFog
 {
-	private static final Height biomeHeight = new Height(2.0F, 3.0F);
+	//private static final Height biomeHeight = new Height(2.0F, 3.0F);
+	private static final Height biomeHeight = new Height(2.0F*BOPConfigurationTerrainGen.heightrootmod, 3.0F*BOPConfigurationTerrainGen.heightvarmod);
 	
 	public BiomeGenCrag(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenDeadForest.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenDeadForest.java
@@ -14,10 +14,13 @@ import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBOPTaiga2;
 import biomesoplenty.common.world.features.trees.WorldGenDeadTree;
 import biomesoplenty.common.world.features.trees.WorldGenOriginalTree;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenDeadForest extends BOPOverworldBiome
 {
-	private static final Height biomeHeight = new Height(0.1F, 0.3F);
+	//private static final Height biomeHeight = new Height(0.1F, 0.3F);
+	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.3F*BOPConfigurationTerrainGen.heightvarmod);
 
 	public BiomeGenDeadForest(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenDeadForest.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenDeadForest.java
@@ -15,12 +15,12 @@ import biomesoplenty.common.world.features.trees.WorldGenBOPTaiga2;
 import biomesoplenty.common.world.features.trees.WorldGenDeadTree;
 import biomesoplenty.common.world.features.trees.WorldGenOriginalTree;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenDeadForest extends BOPOverworldBiome
 {
 	//private static final Height biomeHeight = new Height(0.1F, 0.3F);
-	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.3F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.3F*BOPConfigurationTerrainGen.heightVarMod);
 
 	public BiomeGenDeadForest(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenDeadSwamp.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenDeadSwamp.java
@@ -14,12 +14,12 @@ import biomesoplenty.common.world.features.WorldGenBOPDoubleFlora;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenDeadTree;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenDeadSwamp extends BOPOverworldBiome implements IBiomeFog
 {
     //private static final Height biomeHeight = new Height(0.0F, 0.1F);
-  	private static final Height biomeHeight = new Height(0.0F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightvarmod);
+  	private static final Height biomeHeight = new Height(0.0F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightVarMod);
   
 	public BiomeGenDeadSwamp(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenDeadSwamp.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenDeadSwamp.java
@@ -13,11 +13,14 @@ import biomesoplenty.common.configuration.BOPConfigurationMisc;
 import biomesoplenty.common.world.features.WorldGenBOPDoubleFlora;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenDeadTree;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenDeadSwamp extends BOPOverworldBiome implements IBiomeFog
 {
-    private static final Height biomeHeight = new Height(0.0F, 0.1F);
-    
+    //private static final Height biomeHeight = new Height(0.0F, 0.1F);
+  	private static final Height biomeHeight = new Height(0.0F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightvarmod);
+  
 	public BiomeGenDeadSwamp(int id)
 	{
 		super(id);

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenDeciduousForest.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenDeciduousForest.java
@@ -11,6 +11,8 @@ import biomesoplenty.api.content.BOPCBlocks;
 import biomesoplenty.common.biome.BOPOverworldBiome;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBulbTree;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenDeciduousForest extends BOPOverworldBiome
 {

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenDeciduousForest.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenDeciduousForest.java
@@ -12,7 +12,7 @@ import biomesoplenty.common.biome.BOPOverworldBiome;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBulbTree;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenDeciduousForest extends BOPOverworldBiome
 {

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenFen.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenFen.java
@@ -16,11 +16,14 @@ import biomesoplenty.common.world.features.WorldGenMoss;
 import biomesoplenty.common.world.features.trees.WorldGenBOPTaiga1;
 import biomesoplenty.common.world.features.trees.WorldGenBOPTaiga2;
 import biomesoplenty.common.world.features.trees.WorldGenDeadTree;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenFen extends BOPOverworldBiome implements IBiomeFog
 {
-    private static final Height biomeHeight = new Height(0.1F, 0.1F);
-    
+    //private static final Height biomeHeight = new Height(0.1F, 0.1F);
+ 	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightvarmod);
+   
 	public BiomeGenFen(int id)
 	{
 		super(id);

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenFen.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenFen.java
@@ -17,12 +17,12 @@ import biomesoplenty.common.world.features.trees.WorldGenBOPTaiga1;
 import biomesoplenty.common.world.features.trees.WorldGenBOPTaiga2;
 import biomesoplenty.common.world.features.trees.WorldGenDeadTree;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenFen extends BOPOverworldBiome implements IBiomeFog
 {
     //private static final Height biomeHeight = new Height(0.1F, 0.1F);
- 	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightvarmod);
+ 	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightVarMod);
    
 	public BiomeGenFen(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenFlowerField.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenFlowerField.java
@@ -13,12 +13,12 @@ import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenFlowerField extends BOPOverworldBiome
 {
 	//private static final Height biomeHeight = new Height(0.125F, 0.05F);
-	private static final Height biomeHeight = new Height(0.125F*BOPConfigurationTerrainGen.heightrootmod, 0.05F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(0.125F*BOPConfigurationTerrainGen.heightrootmod, 0.05F*BOPConfigurationTerrainGen.heightVarMod);
 
 	public BiomeGenFlowerField(int par1)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenFlowerField.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenFlowerField.java
@@ -12,10 +12,13 @@ import biomesoplenty.common.world.features.WorldGenBOPFlora;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenFlowerField extends BOPOverworldBiome
 {
-	private static final Height biomeHeight = new Height(0.125F, 0.05F);
+	//private static final Height biomeHeight = new Height(0.125F, 0.05F);
+	private static final Height biomeHeight = new Height(0.125F*BOPConfigurationTerrainGen.heightrootmod, 0.05F*BOPConfigurationTerrainGen.heightvarmod);
 
 	public BiomeGenFlowerField(int par1)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenFrostForest.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenFrostForest.java
@@ -13,12 +13,12 @@ import biomesoplenty.common.biome.BOPOverworldBiome;
 import biomesoplenty.common.configuration.BOPConfigurationMisc;
 import biomesoplenty.common.world.features.WorldGenBOPFlora;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenFrostForest extends BOPOverworldBiome implements IBiomeFog
 {
 	//private static final Height biomeHeight = new Height(0.1F, 0.2F);
-	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.2F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.2F*BOPConfigurationTerrainGen.heightVarMod);
 
 	public BiomeGenFrostForest(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenFrostForest.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenFrostForest.java
@@ -12,11 +12,14 @@ import biomesoplenty.client.fog.IBiomeFog;
 import biomesoplenty.common.biome.BOPOverworldBiome;
 import biomesoplenty.common.configuration.BOPConfigurationMisc;
 import biomesoplenty.common.world.features.WorldGenBOPFlora;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenFrostForest extends BOPOverworldBiome implements IBiomeFog
 {
-	private static final Height biomeHeight = new Height(0.1F, 0.2F);
-	
+	//private static final Height biomeHeight = new Height(0.1F, 0.2F);
+	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.2F*BOPConfigurationTerrainGen.heightvarmod);
+
 	public BiomeGenFrostForest(int id)
 	{
 		super(id);

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenFungiForest.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenFungiForest.java
@@ -18,10 +18,13 @@ import biomesoplenty.common.world.features.WorldGenBOPFlora;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.WorldGenMoss;
 import biomesoplenty.common.world.features.trees.WorldGenBOPTaiga3;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenFungiForest extends BOPOverworldBiome
 {
-    private static final Height biomeHeight = new Height(0.2F, 0.5F);
+    //private static final Height biomeHeight = new Height(0.2F, 0.5F);
+	private static final Height biomeHeight = new Height(0.2F*BOPConfigurationTerrainGen.heightrootmod, 0.5F*BOPConfigurationTerrainGen.heightvarmod);
 	
 	public BiomeGenFungiForest(int biomeID)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenFungiForest.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenFungiForest.java
@@ -19,12 +19,12 @@ import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.WorldGenMoss;
 import biomesoplenty.common.world.features.trees.WorldGenBOPTaiga3;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenFungiForest extends BOPOverworldBiome
 {
     //private static final Height biomeHeight = new Height(0.2F, 0.5F);
-	private static final Height biomeHeight = new Height(0.2F*BOPConfigurationTerrainGen.heightrootmod, 0.5F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(0.2F*BOPConfigurationTerrainGen.heightrootmod, 0.5F*BOPConfigurationTerrainGen.heightVarMod);
 	
 	public BiomeGenFungiForest(int biomeID)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenGarden.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenGarden.java
@@ -17,12 +17,12 @@ import biomesoplenty.common.world.features.WorldGenBOPDoubleFlora;
 import biomesoplenty.common.world.features.WorldGenBOPFlora;
 import biomesoplenty.common.world.features.trees.WorldGenGiantFlower;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenGarden extends BOPOverworldBiome
 {
     //private static final Height biomeHeight = new Height(0.1F, 0.1F);
-	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightVarMod);
 	
 	public BiomeGenGarden(int biomeID) 
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenGarden.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenGarden.java
@@ -16,10 +16,13 @@ import biomesoplenty.common.entities.EntityRosester;
 import biomesoplenty.common.world.features.WorldGenBOPDoubleFlora;
 import biomesoplenty.common.world.features.WorldGenBOPFlora;
 import biomesoplenty.common.world.features.trees.WorldGenGiantFlower;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenGarden extends BOPOverworldBiome
 {
-    private static final Height biomeHeight = new Height(0.1F, 0.1F);
+    //private static final Height biomeHeight = new Height(0.1F, 0.1F);
+	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightvarmod);
 	
 	public BiomeGenGarden(int biomeID) 
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenGrassland.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenGrassland.java
@@ -15,10 +15,13 @@ import net.minecraft.world.biome.BiomeGenBase.SpawnListEntry;
 import net.minecraft.world.gen.feature.WorldGenTallGrass;
 import biomesoplenty.api.content.BOPCBlocks;
 import biomesoplenty.common.biome.BOPOverworldBiome;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenGrassland extends BOPOverworldBiome
 {
-	private static final Height biomeHeight = new Height(0.1F, 0.2F);
+	//private static final Height biomeHeight = new Height(0.1F, 0.2F);
+	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.2F*BOPConfigurationTerrainGen.heightvarmod);
 	
 	public BiomeGenGrassland(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenGrassland.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenGrassland.java
@@ -16,12 +16,12 @@ import net.minecraft.world.gen.feature.WorldGenTallGrass;
 import biomesoplenty.api.content.BOPCBlocks;
 import biomesoplenty.common.biome.BOPOverworldBiome;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenGrassland extends BOPOverworldBiome
 {
 	//private static final Height biomeHeight = new Height(0.1F, 0.2F);
-	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.2F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.2F*BOPConfigurationTerrainGen.heightVarMod);
 	
 	public BiomeGenGrassland(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenGrove.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenGrove.java
@@ -15,10 +15,13 @@ import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenMiniShrub;
 import biomesoplenty.common.world.features.trees.WorldGenPoplar;
 import biomesoplenty.common.world.features.trees.WorldGenPoplar2;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenGrove extends BOPOverworldBiome
 {
-    private static final Height biomeHeight = new Height(0.1F, 0.2F);
+    //private static final Height biomeHeight = new Height(0.1F, 0.2F);
+	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.2F*BOPConfigurationTerrainGen.heightvarmod);
 
 	public BiomeGenGrove(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenGrove.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenGrove.java
@@ -16,12 +16,12 @@ import biomesoplenty.common.world.features.trees.WorldGenMiniShrub;
 import biomesoplenty.common.world.features.trees.WorldGenPoplar;
 import biomesoplenty.common.world.features.trees.WorldGenPoplar2;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenGrove extends BOPOverworldBiome
 {
     //private static final Height biomeHeight = new Height(0.1F, 0.2F);
-	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.2F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.2F*BOPConfigurationTerrainGen.heightVarMod);
 
 	public BiomeGenGrove(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenHeathland.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenHeathland.java
@@ -16,10 +16,13 @@ import biomesoplenty.common.world.features.WorldGenBOPDoubleFlora;
 import biomesoplenty.common.world.features.WorldGenBOPFlora;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBOPShrub;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenHeathland extends BOPOverworldBiome
 {
-    private static final Height biomeHeight = new Height(0.1F, 0.2F);
+    //private static final Height biomeHeight = new Height(0.1F, 0.2F);
+	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.2F*BOPConfigurationTerrainGen.heightvarmod);
 
 	public BiomeGenHeathland(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenHeathland.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenHeathland.java
@@ -17,12 +17,12 @@ import biomesoplenty.common.world.features.WorldGenBOPFlora;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBOPShrub;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenHeathland extends BOPOverworldBiome
 {
     //private static final Height biomeHeight = new Height(0.1F, 0.2F);
-	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.2F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.2F*BOPConfigurationTerrainGen.heightVarMod);
 
 	public BiomeGenHeathland(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenHighland.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenHighland.java
@@ -11,12 +11,12 @@ import biomesoplenty.common.biome.BOPOverworldBiome;
 import biomesoplenty.common.world.features.WorldGenBOPDoubleFlora;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenHighland extends BOPOverworldBiome
 {
 	//private static final Height biomeHeight = new Height(2.5F, 0.5F);
-	private static final Height biomeHeight = new Height(2.5F*BOPConfigurationTerrainGen.heightrootmod, 0.5F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(2.5F*BOPConfigurationTerrainGen.heightrootmod, 0.5F*BOPConfigurationTerrainGen.heightVarMod);
 
 	public BiomeGenHighland(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenHighland.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenHighland.java
@@ -10,10 +10,13 @@ import biomesoplenty.api.content.BOPCBlocks;
 import biomesoplenty.common.biome.BOPOverworldBiome;
 import biomesoplenty.common.world.features.WorldGenBOPDoubleFlora;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenHighland extends BOPOverworldBiome
 {
-	private static final Height biomeHeight = new Height(2.5F, 0.5F);
+	//private static final Height biomeHeight = new Height(2.5F, 0.5F);
+	private static final Height biomeHeight = new Height(2.5F*BOPConfigurationTerrainGen.heightrootmod, 0.5F*BOPConfigurationTerrainGen.heightvarmod);
 
 	public BiomeGenHighland(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenJadeCliffs.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenJadeCliffs.java
@@ -16,12 +16,12 @@ import biomesoplenty.common.configuration.BOPConfigurationMisc;
 import biomesoplenty.common.world.features.WorldGenBOPDoubleFlora;
 import biomesoplenty.common.world.features.trees.WorldGenPineTree;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenJadeCliffs extends BOPOverworldBiome
 {
 	//private static final Height biomeHeight = new Height(0.5F, 1.0F);
-	private static final Height biomeHeight = new Height(0.5F*BOPConfigurationTerrainGen.heightrootmod, 1.0F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(0.5F*BOPConfigurationTerrainGen.heightrootmod, 1.0F*BOPConfigurationTerrainGen.heightVarMod);
 	
 	public BiomeGenJadeCliffs(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenJadeCliffs.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenJadeCliffs.java
@@ -15,10 +15,13 @@ import biomesoplenty.common.biome.BOPOverworldBiome;
 import biomesoplenty.common.configuration.BOPConfigurationMisc;
 import biomesoplenty.common.world.features.WorldGenBOPDoubleFlora;
 import biomesoplenty.common.world.features.trees.WorldGenPineTree;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenJadeCliffs extends BOPOverworldBiome
 {
-	private static final Height biomeHeight = new Height(0.5F, 1.0F);
+	//private static final Height biomeHeight = new Height(0.5F, 1.0F);
+	private static final Height biomeHeight = new Height(0.5F*BOPConfigurationTerrainGen.heightrootmod, 1.0F*BOPConfigurationTerrainGen.heightvarmod);
 	
 	public BiomeGenJadeCliffs(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenLavenderFields.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenLavenderFields.java
@@ -13,12 +13,12 @@ import biomesoplenty.api.content.BOPCBlocks;
 import biomesoplenty.common.biome.BOPOverworldBiome;
 import biomesoplenty.common.world.features.trees.WorldGenOriginalTree;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenLavenderFields extends BOPOverworldBiome
 {
 	//private static final Height biomeHeight = new Height(0.125F, 0.05F);
-	private static final Height biomeHeight = new Height(0.125F*BOPConfigurationTerrainGen.heightrootmod, 0.05F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(0.125F*BOPConfigurationTerrainGen.heightrootmod, 0.05F*BOPConfigurationTerrainGen.heightVarMod);
 	
 	public BiomeGenLavenderFields(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenLavenderFields.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenLavenderFields.java
@@ -12,10 +12,13 @@ import net.minecraft.world.gen.feature.WorldGenerator;
 import biomesoplenty.api.content.BOPCBlocks;
 import biomesoplenty.common.biome.BOPOverworldBiome;
 import biomesoplenty.common.world.features.trees.WorldGenOriginalTree;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenLavenderFields extends BOPOverworldBiome
 {
-	private static final Height biomeHeight = new Height(0.125F, 0.05F);
+	//private static final Height biomeHeight = new Height(0.125F, 0.05F);
+	private static final Height biomeHeight = new Height(0.125F*BOPConfigurationTerrainGen.heightrootmod, 0.05F*BOPConfigurationTerrainGen.heightvarmod);
 	
 	public BiomeGenLavenderFields(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenLushDesert.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenLushDesert.java
@@ -18,12 +18,12 @@ import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenCypress;
 import biomesoplenty.common.world.features.trees.WorldGenDeadTree;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenLushDesert extends BOPOverworldBiome
 {
     //private static final Height biomeHeight = new Height(0.2F, 0.5F);
-	private static final Height biomeHeight = new Height(0.2F*BOPConfigurationTerrainGen.heightrootmod, 0.5F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(0.2F*BOPConfigurationTerrainGen.heightrootmod, 0.5F*BOPConfigurationTerrainGen.heightVarMod);
     
     public BiomeGenLushDesert(int id)
     {

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenLushDesert.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenLushDesert.java
@@ -17,10 +17,13 @@ import biomesoplenty.common.world.features.WorldGenBOPFlora;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenCypress;
 import biomesoplenty.common.world.features.trees.WorldGenDeadTree;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenLushDesert extends BOPOverworldBiome
 {
-    private static final Height biomeHeight = new Height(0.2F, 0.5F);
+    //private static final Height biomeHeight = new Height(0.2F, 0.5F);
+	private static final Height biomeHeight = new Height(0.2F*BOPConfigurationTerrainGen.heightrootmod, 0.5F*BOPConfigurationTerrainGen.heightvarmod);
     
     public BiomeGenLushDesert(int id)
     {

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenLushSwamp.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenLushSwamp.java
@@ -14,10 +14,13 @@ import biomesoplenty.common.biome.BOPOverworldBiome;
 import biomesoplenty.common.world.features.WorldGenBOPFlora;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBOPSwampTree;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenLushSwamp extends BOPOverworldBiome
 {
-    private static final Height biomeHeight = new Height(0.0F, 0.1F);
+    //private static final Height biomeHeight = new Height(0.0F, 0.1F);
+	private static final Height biomeHeight = new Height(0.0F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightvarmod);
 
     public BiomeGenLushSwamp(int id)
     {

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenLushSwamp.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenLushSwamp.java
@@ -15,12 +15,12 @@ import biomesoplenty.common.world.features.WorldGenBOPFlora;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBOPSwampTree;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenLushSwamp extends BOPOverworldBiome
 {
     //private static final Height biomeHeight = new Height(0.0F, 0.1F);
-	private static final Height biomeHeight = new Height(0.0F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(0.0F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightVarMod);
 
     public BiomeGenLushSwamp(int id)
     {

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenMapleWoods.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenMapleWoods.java
@@ -14,12 +14,12 @@ import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBOPTaiga2;
 import biomesoplenty.common.world.features.trees.WorldGenOriginalTree;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenMapleWoods extends BOPOverworldBiome
 {
     //private static final Height biomeHeight = new Height(0.1F, 0.3F);
- 	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.3F*BOPConfigurationTerrainGen.heightvarmod);
+ 	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.3F*BOPConfigurationTerrainGen.heightVarMod);
    
 	public BiomeGenMapleWoods(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenMapleWoods.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenMapleWoods.java
@@ -13,11 +13,14 @@ import biomesoplenty.common.world.features.WorldGenBOPFlora;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBOPTaiga2;
 import biomesoplenty.common.world.features.trees.WorldGenOriginalTree;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenMapleWoods extends BOPOverworldBiome
 {
-    private static final Height biomeHeight = new Height(0.1F, 0.3F);
-    
+    //private static final Height biomeHeight = new Height(0.1F, 0.3F);
+ 	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.3F*BOPConfigurationTerrainGen.heightvarmod);
+   
 	public BiomeGenMapleWoods(int id)
 	{
 		super(id);

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenMarsh.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenMarsh.java
@@ -12,10 +12,13 @@ import biomesoplenty.api.content.BOPCBlocks;
 import biomesoplenty.common.biome.BOPOverworldBiome;
 import biomesoplenty.common.world.features.WorldGenBOPDoubleFlora;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenMarsh extends BOPOverworldBiome
 {
-	private static final Height biomeHeight = new Height(0.125F, 0.05F);
+	//private static final Height biomeHeight = new Height(0.125F, 0.05F);
+	private static final Height biomeHeight = new Height(0.125F*BOPConfigurationTerrainGen.heightrootmod, 0.05F*BOPConfigurationTerrainGen.heightvarmod);
 	
 	public BiomeGenMarsh(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenMarsh.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenMarsh.java
@@ -13,12 +13,12 @@ import biomesoplenty.common.biome.BOPOverworldBiome;
 import biomesoplenty.common.world.features.WorldGenBOPDoubleFlora;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenMarsh extends BOPOverworldBiome
 {
 	//private static final Height biomeHeight = new Height(0.125F, 0.05F);
-	private static final Height biomeHeight = new Height(0.125F*BOPConfigurationTerrainGen.heightrootmod, 0.05F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(0.125F*BOPConfigurationTerrainGen.heightrootmod, 0.05F*BOPConfigurationTerrainGen.heightVarMod);
 	
 	public BiomeGenMarsh(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenMeadow.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenMeadow.java
@@ -16,7 +16,7 @@ import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBOPShrub;
 import biomesoplenty.common.world.features.trees.WorldGenBOPTaiga2;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenMeadow extends BOPOverworldBiome
 {

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenMeadow.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenMeadow.java
@@ -15,6 +15,8 @@ import biomesoplenty.common.world.features.WorldGenBOPFlora;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBOPShrub;
 import biomesoplenty.common.world.features.trees.WorldGenBOPTaiga2;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenMeadow extends BOPOverworldBiome
 {

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenMoor.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenMoor.java
@@ -12,12 +12,12 @@ import biomesoplenty.common.configuration.BOPConfigurationMisc;
 import biomesoplenty.common.world.features.WorldGenBOPFlora;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenMoor extends BOPOverworldBiome
 {
     //private static final Height biomeHeight = new Height(1.5F, 0.025F);
-	private static final Height biomeHeight = new Height(1.5F*BOPConfigurationTerrainGen.heightrootmod, 0.025F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(1.5F*BOPConfigurationTerrainGen.heightrootmod, 0.025F*BOPConfigurationTerrainGen.heightVarMod);
     
 	public BiomeGenMoor(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenMoor.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenMoor.java
@@ -11,10 +11,13 @@ import biomesoplenty.common.biome.BOPOverworldBiome;
 import biomesoplenty.common.configuration.BOPConfigurationMisc;
 import biomesoplenty.common.world.features.WorldGenBOPFlora;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenMoor extends BOPOverworldBiome
 {
-    private static final Height biomeHeight = new Height(1.5F, 0.025F);
+    //private static final Height biomeHeight = new Height(1.5F, 0.025F);
+	private static final Height biomeHeight = new Height(1.5F*BOPConfigurationTerrainGen.heightrootmod, 0.025F*BOPConfigurationTerrainGen.heightvarmod);
     
 	public BiomeGenMoor(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenMountain.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenMountain.java
@@ -13,10 +13,13 @@ import biomesoplenty.api.content.BOPCBlocks;
 import biomesoplenty.common.biome.BOPOverworldBiome;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenPineTree;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenMountain extends BOPOverworldBiome
 {
-	private static final Height biomeHeight = new Height(2.5F, 0.5F);
+	//private static final Height biomeHeight = new Height(2.5F, 0.5F);
+	private static final Height biomeHeight = new Height(2.5F*BOPConfigurationTerrainGen.heightrootmod, 0.5F*BOPConfigurationTerrainGen.heightvarmod);
 
 	public BiomeGenMountain(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenMountain.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenMountain.java
@@ -14,12 +14,12 @@ import biomesoplenty.common.biome.BOPOverworldBiome;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenPineTree;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenMountain extends BOPOverworldBiome
 {
 	//private static final Height biomeHeight = new Height(2.5F, 0.5F);
-	private static final Height biomeHeight = new Height(2.5F*BOPConfigurationTerrainGen.heightrootmod, 0.5F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(2.5F*BOPConfigurationTerrainGen.heightrootmod, 0.5F*BOPConfigurationTerrainGen.heightVarMod);
 
 	public BiomeGenMountain(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenMysticGrove.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenMysticGrove.java
@@ -17,12 +17,12 @@ import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBOPSwampTree;
 import biomesoplenty.common.world.features.trees.WorldGenOriginalTree;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenMysticGrove extends BOPOverworldBiome implements IBiomeFog
 {
     //private static final Height biomeHeight = new Height(0.1F, 0.2F);
-	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.2F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.2F*BOPConfigurationTerrainGen.heightVarMod);
 
 	public BiomeGenMysticGrove(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenMysticGrove.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenMysticGrove.java
@@ -16,10 +16,13 @@ import biomesoplenty.common.world.features.WorldGenBOPFlora;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBOPSwampTree;
 import biomesoplenty.common.world.features.trees.WorldGenOriginalTree;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenMysticGrove extends BOPOverworldBiome implements IBiomeFog
 {
-    private static final Height biomeHeight = new Height(0.1F, 0.2F);
+    //private static final Height biomeHeight = new Height(0.1F, 0.2F);
+	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.2F*BOPConfigurationTerrainGen.heightvarmod);
 
 	public BiomeGenMysticGrove(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenOminousWoods.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenOminousWoods.java
@@ -18,10 +18,13 @@ import biomesoplenty.common.world.features.WorldGenBOPFlora;
 import biomesoplenty.common.world.features.trees.WorldGenBOPSwampTree;
 import biomesoplenty.common.world.features.trees.WorldGenBOPTaiga2;
 import biomesoplenty.common.world.features.trees.WorldGenDeadTree;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenOminousWoods extends BOPOverworldBiome implements IBiomeFog
 {
-	private static final Height biomeHeight = new Height(0.1F, 0.2F);
+	//private static final Height biomeHeight = new Height(0.1F, 0.2F);
+	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.2F*BOPConfigurationTerrainGen.heightvarmod);
 	
 	public BiomeGenOminousWoods(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenOminousWoods.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenOminousWoods.java
@@ -19,12 +19,12 @@ import biomesoplenty.common.world.features.trees.WorldGenBOPSwampTree;
 import biomesoplenty.common.world.features.trees.WorldGenBOPTaiga2;
 import biomesoplenty.common.world.features.trees.WorldGenDeadTree;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenOminousWoods extends BOPOverworldBiome implements IBiomeFog
 {
 	//private static final Height biomeHeight = new Height(0.1F, 0.2F);
-	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.2F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.2F*BOPConfigurationTerrainGen.heightVarMod);
 	
 	public BiomeGenOminousWoods(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenOriginValley.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenOriginValley.java
@@ -11,12 +11,12 @@ import biomesoplenty.common.configuration.BOPConfigurationMisc;
 import biomesoplenty.common.world.features.WorldGenBOPFlora;
 import biomesoplenty.common.world.features.trees.WorldGenOriginalTree;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenOriginValley extends BOPOverworldBiome
 {
     //private static final Height biomeHeight = new Height(0.1F, 0.3F);
-	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.3F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.3F*BOPConfigurationTerrainGen.heightVarMod);
 
 	public BiomeGenOriginValley(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenOriginValley.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenOriginValley.java
@@ -10,10 +10,13 @@ import biomesoplenty.common.biome.BOPOverworldBiome;
 import biomesoplenty.common.configuration.BOPConfigurationMisc;
 import biomesoplenty.common.world.features.WorldGenBOPFlora;
 import biomesoplenty.common.world.features.trees.WorldGenOriginalTree;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenOriginValley extends BOPOverworldBiome
 {
-    private static final Height biomeHeight = new Height(0.1F, 0.3F);
+    //private static final Height biomeHeight = new Height(0.1F, 0.3F);
+	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.3F*BOPConfigurationTerrainGen.heightvarmod);
 
 	public BiomeGenOriginValley(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenOutback.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenOutback.java
@@ -11,10 +11,13 @@ import biomesoplenty.api.content.BOPCBlocks;
 import biomesoplenty.common.biome.BOPOverworldBiome;
 import biomesoplenty.common.world.features.trees.WorldGenBOPShrub;
 import biomesoplenty.common.world.features.trees.WorldGenMiniShrub;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenOutback extends BOPOverworldBiome
 {
-    private static final Height biomeHeight = new Height(0.1F, 0.1F);
+    //private static final Height biomeHeight = new Height(0.1F, 0.1F);
+	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightvarmod);
 
 	public BiomeGenOutback(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenOutback.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenOutback.java
@@ -12,12 +12,12 @@ import biomesoplenty.common.biome.BOPOverworldBiome;
 import biomesoplenty.common.world.features.trees.WorldGenBOPShrub;
 import biomesoplenty.common.world.features.trees.WorldGenMiniShrub;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenOutback extends BOPOverworldBiome
 {
     //private static final Height biomeHeight = new Height(0.1F, 0.1F);
-	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightVarMod);
 
 	public BiomeGenOutback(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenPrairie.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenPrairie.java
@@ -14,10 +14,13 @@ import biomesoplenty.common.biome.BOPOverworldBiome;
 import biomesoplenty.common.world.features.WorldGenBOPFlora;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBOPTaiga2;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenPrairie extends BOPOverworldBiome
 {
-    private static final Height biomeHeight = new Height(0.1F, 0.1F);
+    //private static final Height biomeHeight = new Height(0.1F, 0.1F);
+	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightvarmod);
     
 	public BiomeGenPrairie(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenPrairie.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenPrairie.java
@@ -15,12 +15,12 @@ import biomesoplenty.common.world.features.WorldGenBOPFlora;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBOPTaiga2;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenPrairie extends BOPOverworldBiome
 {
     //private static final Height biomeHeight = new Height(0.1F, 0.1F);
-	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightVarMod);
     
 	public BiomeGenPrairie(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenRainforest.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenRainforest.java
@@ -17,10 +17,13 @@ import biomesoplenty.common.entities.EntityJungleSpider;
 import biomesoplenty.common.world.features.WorldGenBOPDoubleFlora;
 import biomesoplenty.common.world.features.WorldGenBOPFlora;
 import biomesoplenty.common.world.features.trees.WorldGenOriginalTree;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenRainforest extends BOPOverworldBiome
 {
-	private static final Height biomeHeight = new Height(0.2F, 0.9F);
+	//private static final Height biomeHeight = new Height(0.2F, 0.9F);
+	private static final Height biomeHeight = new Height(0.2F*BOPConfigurationTerrainGen.heightrootmod, 0.9F*BOPConfigurationTerrainGen.heightvarmod);
 
 	public BiomeGenRainforest(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenRainforest.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenRainforest.java
@@ -18,12 +18,12 @@ import biomesoplenty.common.world.features.WorldGenBOPDoubleFlora;
 import biomesoplenty.common.world.features.WorldGenBOPFlora;
 import biomesoplenty.common.world.features.trees.WorldGenOriginalTree;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenRainforest extends BOPOverworldBiome
 {
 	//private static final Height biomeHeight = new Height(0.2F, 0.9F);
-	private static final Height biomeHeight = new Height(0.2F*BOPConfigurationTerrainGen.heightrootmod, 0.9F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(0.2F*BOPConfigurationTerrainGen.heightrootmod, 0.9F*BOPConfigurationTerrainGen.heightVarMod);
 
 	public BiomeGenRainforest(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenRedwoodForest.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenRedwoodForest.java
@@ -16,12 +16,12 @@ import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenRedwoodTree;
 import biomesoplenty.common.world.features.trees.WorldGenRedwoodTree2;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenRedwoodForest extends BOPOverworldBiome
 {
     //private static final Height biomeHeight = new Height(0.1F, 0.1F);
- 	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightvarmod);
+ 	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightVarMod);
    
     public BiomeGenRedwoodForest(int id)
     {

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenRedwoodForest.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenRedwoodForest.java
@@ -15,11 +15,14 @@ import biomesoplenty.common.world.features.WorldGenBOPFlora;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenRedwoodTree;
 import biomesoplenty.common.world.features.trees.WorldGenRedwoodTree2;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenRedwoodForest extends BOPOverworldBiome
 {
-    private static final Height biomeHeight = new Height(0.1F, 0.1F);
-    
+    //private static final Height biomeHeight = new Height(0.1F, 0.1F);
+ 	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightvarmod);
+   
     public BiomeGenRedwoodForest(int id)
     {
         super(id);

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenSacredSprings.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenSacredSprings.java
@@ -19,10 +19,13 @@ import biomesoplenty.common.world.features.WorldGenBOPFlora;
 import biomesoplenty.common.world.features.trees.WorldGenSacredOak;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenSacredSprings extends BOPOverworldBiome
 {
-	private static final Height biomeHeight = new Height(0.0F, 0.6F);
+	//private static final Height biomeHeight = new Height(0.0F, 0.6F);
+	private static final Height biomeHeight = new Height(0.0F*BOPConfigurationTerrainGen.heightrootmod, 0.6F*BOPConfigurationTerrainGen.heightvarmod);
 	
     public BiomeGenSacredSprings(int id)
     {

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenSacredSprings.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenSacredSprings.java
@@ -20,12 +20,12 @@ import biomesoplenty.common.world.features.trees.WorldGenSacredOak;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenSacredSprings extends BOPOverworldBiome
 {
 	//private static final Height biomeHeight = new Height(0.0F, 0.6F);
-	private static final Height biomeHeight = new Height(0.0F*BOPConfigurationTerrainGen.heightrootmod, 0.6F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(0.0F*BOPConfigurationTerrainGen.heightrootmod, 0.6F*BOPConfigurationTerrainGen.heightVarMod);
 	
     public BiomeGenSacredSprings(int id)
     {

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenSeasonalForest.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenSeasonalForest.java
@@ -16,12 +16,12 @@ import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBOPBigTree;
 import biomesoplenty.common.world.features.trees.WorldGenOriginalTree;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenSeasonalForest extends BOPOverworldBiome implements IBiomeFog
 {
     //private static final Height biomeHeight = new Height(0.2F, 0.4F);
-	private static final Height biomeHeight = new Height(0.2F*BOPConfigurationTerrainGen.heightrootmod, 0.4F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(0.2F*BOPConfigurationTerrainGen.heightrootmod, 0.4F*BOPConfigurationTerrainGen.heightVarMod);
 
     public BiomeGenSeasonalForest(int id)
     {

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenSeasonalForest.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenSeasonalForest.java
@@ -15,10 +15,13 @@ import biomesoplenty.common.biome.BOPOverworldBiome;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBOPBigTree;
 import biomesoplenty.common.world.features.trees.WorldGenOriginalTree;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenSeasonalForest extends BOPOverworldBiome implements IBiomeFog
 {
-    private static final Height biomeHeight = new Height(0.2F, 0.4F);
+    //private static final Height biomeHeight = new Height(0.2F, 0.4F);
+	private static final Height biomeHeight = new Height(0.2F*BOPConfigurationTerrainGen.heightrootmod, 0.4F*BOPConfigurationTerrainGen.heightvarmod);
 
     public BiomeGenSeasonalForest(int id)
     {

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenShield.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenShield.java
@@ -15,12 +15,12 @@ import biomesoplenty.common.world.features.WorldGenMoss;
 import biomesoplenty.common.world.features.trees.WorldGenBOPTaiga2;
 import biomesoplenty.common.world.features.trees.WorldGenPineTree;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenShield extends BOPOverworldBiome
 {
     //private static final Height biomeHeight = new Height(0.0F, 0.2F);
-	private static final Height biomeHeight = new Height(0.0F*BOPConfigurationTerrainGen.heightrootmod, 0.2F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(0.0F*BOPConfigurationTerrainGen.heightrootmod, 0.2F*BOPConfigurationTerrainGen.heightVarMod);
 
 	public BiomeGenShield(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenShield.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenShield.java
@@ -14,10 +14,13 @@ import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.WorldGenMoss;
 import biomesoplenty.common.world.features.trees.WorldGenBOPTaiga2;
 import biomesoplenty.common.world.features.trees.WorldGenPineTree;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenShield extends BOPOverworldBiome
 {
-    private static final Height biomeHeight = new Height(0.0F, 0.2F);
+    //private static final Height biomeHeight = new Height(0.0F, 0.2F);
+	private static final Height biomeHeight = new Height(0.0F*BOPConfigurationTerrainGen.heightrootmod, 0.2F*BOPConfigurationTerrainGen.heightvarmod);
 
 	public BiomeGenShield(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenShrubland.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenShrubland.java
@@ -14,10 +14,13 @@ import biomesoplenty.api.content.BOPCBlocks;
 import biomesoplenty.common.biome.BOPOverworldBiome;
 import biomesoplenty.common.world.features.WorldGenBOPFlora;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenShrubland extends BOPOverworldBiome
 {
-	private static final Height biomeHeight = new Height(0.1F, 0.1F);
+	//private static final Height biomeHeight = new Height(0.1F, 0.1F);
+	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightvarmod);
 	
 	public BiomeGenShrubland(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenShrubland.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenShrubland.java
@@ -15,12 +15,12 @@ import biomesoplenty.common.biome.BOPOverworldBiome;
 import biomesoplenty.common.world.features.WorldGenBOPFlora;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenShrubland extends BOPOverworldBiome
 {
 	//private static final Height biomeHeight = new Height(0.1F, 0.1F);
-	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightVarMod);
 	
 	public BiomeGenShrubland(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenSludgepit.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenSludgepit.java
@@ -14,12 +14,12 @@ import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBogTree1;
 import biomesoplenty.common.world.features.trees.WorldGenBogTree2;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenSludgepit extends BOPOverworldBiome implements IBiomeFog
 {
     //private static final Height biomeHeight = new Height(0.0F, 0.1F);
-	private static final Height biomeHeight = new Height(0.0F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(0.0F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightVarMod);
 
     public BiomeGenSludgepit(int id)
     {

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenSludgepit.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenSludgepit.java
@@ -13,10 +13,13 @@ import biomesoplenty.common.configuration.BOPConfigurationMisc;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBogTree1;
 import biomesoplenty.common.world.features.trees.WorldGenBogTree2;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenSludgepit extends BOPOverworldBiome implements IBiomeFog
 {
-    private static final Height biomeHeight = new Height(0.0F, 0.1F);
+    //private static final Height biomeHeight = new Height(0.0F, 0.1F);
+	private static final Height biomeHeight = new Height(0.0F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightvarmod);
 
     public BiomeGenSludgepit(int id)
     {

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenSteppe.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenSteppe.java
@@ -12,12 +12,12 @@ import biomesoplenty.api.content.BOPCBlocks;
 import biomesoplenty.common.biome.BOPOverworldBiome;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenSteppe extends BOPOverworldBiome
 {
 	//private static final Height biomeHeight = new Height(0.1F, 0.3F);
-	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.3F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.3F*BOPConfigurationTerrainGen.heightVarMod);
 	
 	public BiomeGenSteppe(int biomeID) 
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenSteppe.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenSteppe.java
@@ -11,10 +11,13 @@ import net.minecraft.world.biome.BiomeGenBase.SpawnListEntry;
 import biomesoplenty.api.content.BOPCBlocks;
 import biomesoplenty.common.biome.BOPOverworldBiome;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenSteppe extends BOPOverworldBiome
 {
-	private static final Height biomeHeight = new Height(0.1F, 0.3F);
+	//private static final Height biomeHeight = new Height(0.1F, 0.3F);
+	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.3F*BOPConfigurationTerrainGen.heightvarmod);
 	
 	public BiomeGenSteppe(int biomeID) 
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenTemperateRainforest.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenTemperateRainforest.java
@@ -17,10 +17,13 @@ import biomesoplenty.common.world.features.WorldGenMoss;
 import biomesoplenty.common.world.features.trees.WorldGenBOPSwampTree;
 import biomesoplenty.common.world.features.trees.WorldGenBOPTaiga2;
 import biomesoplenty.common.world.features.trees.WorldGenBOPTaiga3;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenTemperateRainforest extends BOPOverworldBiome implements IBiomeFog
 {
-    private static final Height biomeHeight = new Height(0.0F, 0.3F);
+    //private static final Height biomeHeight = new Height(0.0F, 0.3F);
+	private static final Height biomeHeight = new Height(0.0F*BOPConfigurationTerrainGen.heightrootmod, 0.3F*BOPConfigurationTerrainGen.heightvarmod);
 
 	public BiomeGenTemperateRainforest(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenTemperateRainforest.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenTemperateRainforest.java
@@ -18,12 +18,12 @@ import biomesoplenty.common.world.features.trees.WorldGenBOPSwampTree;
 import biomesoplenty.common.world.features.trees.WorldGenBOPTaiga2;
 import biomesoplenty.common.world.features.trees.WorldGenBOPTaiga3;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenTemperateRainforest extends BOPOverworldBiome implements IBiomeFog
 {
     //private static final Height biomeHeight = new Height(0.0F, 0.3F);
-	private static final Height biomeHeight = new Height(0.0F*BOPConfigurationTerrainGen.heightrootmod, 0.3F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(0.0F*BOPConfigurationTerrainGen.heightrootmod, 0.3F*BOPConfigurationTerrainGen.heightVarMod);
 
 	public BiomeGenTemperateRainforest(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenThicket.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenThicket.java
@@ -13,10 +13,13 @@ import net.minecraft.world.gen.feature.WorldGenerator;
 import biomesoplenty.api.content.BOPCBlocks;
 import biomesoplenty.common.biome.BOPOverworldBiome;
 import biomesoplenty.common.world.features.WorldGenBOPFlora;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenThicket extends BOPOverworldBiome
 {
-	private static final Height biomeHeight = new Height(0.1F, 0.1F);
+	//private static final Height biomeHeight = new Height(0.1F, 0.1F);
+	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightvarmod);
 	
 	public BiomeGenThicket(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenThicket.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenThicket.java
@@ -14,12 +14,12 @@ import biomesoplenty.api.content.BOPCBlocks;
 import biomesoplenty.common.biome.BOPOverworldBiome;
 import biomesoplenty.common.world.features.WorldGenBOPFlora;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenThicket extends BOPOverworldBiome
 {
 	//private static final Height biomeHeight = new Height(0.1F, 0.1F);
-	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightVarMod);
 	
 	public BiomeGenThicket(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenTropicalRainforest.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenTropicalRainforest.java
@@ -18,12 +18,12 @@ import biomesoplenty.common.world.features.WorldGenBOPFlora;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenRainforestTree1;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenTropicalRainforest extends BOPOverworldBiome implements IBiomeFog
 {
     //private static final Height biomeHeight = new Height(0.2F, 0.3F);
-	private static final Height biomeHeight = new Height(0.2F*BOPConfigurationTerrainGen.heightrootmod, 0.3F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(0.2F*BOPConfigurationTerrainGen.heightrootmod, 0.3F*BOPConfigurationTerrainGen.heightVarMod);
 
     public BiomeGenTropicalRainforest(int id)
     {

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenTropicalRainforest.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenTropicalRainforest.java
@@ -17,10 +17,13 @@ import biomesoplenty.common.world.features.WorldGenBOPDoubleFlora;
 import biomesoplenty.common.world.features.WorldGenBOPFlora;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenRainforestTree1;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenTropicalRainforest extends BOPOverworldBiome implements IBiomeFog
 {
-    private static final Height biomeHeight = new Height(0.2F, 0.3F);
+    //private static final Height biomeHeight = new Height(0.2F, 0.3F);
+	private static final Height biomeHeight = new Height(0.2F*BOPConfigurationTerrainGen.heightrootmod, 0.3F*BOPConfigurationTerrainGen.heightvarmod);
 
     public BiomeGenTropicalRainforest(int id)
     {

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenTundra.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenTundra.java
@@ -13,12 +13,12 @@ import biomesoplenty.common.biome.BOPOverworldBiome;
 import biomesoplenty.common.world.features.WorldGenBOPFlora;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenTundra extends BOPOverworldBiome
 {
     //private static final Height biomeHeight = new Height(0.0F, 0.1F);
-	private static final Height biomeHeight = new Height(0.0F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(0.0F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightVarMod);
     
     public BiomeGenTundra(int id)
     {

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenTundra.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenTundra.java
@@ -12,10 +12,13 @@ import biomesoplenty.api.content.BOPCBlocks;
 import biomesoplenty.common.biome.BOPOverworldBiome;
 import biomesoplenty.common.world.features.WorldGenBOPFlora;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenTundra extends BOPOverworldBiome
 {
-    private static final Height biomeHeight = new Height(0.0F, 0.1F);
+    //private static final Height biomeHeight = new Height(0.0F, 0.1F);
+	private static final Height biomeHeight = new Height(0.0F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightvarmod);
     
     public BiomeGenTundra(int id)
     {

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenWasteland.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenWasteland.java
@@ -12,10 +12,13 @@ import biomesoplenty.common.biome.BOPOverworldBiome;
 import biomesoplenty.common.configuration.BOPConfigurationMisc;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenDeadTree;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenWasteland extends BOPOverworldBiome implements IBiomeFog
 {
-    private static final Height biomeHeight = new Height(0.1F, 0.1F);
+    //private static final Height biomeHeight = new Height(0.1F, 0.1F);
+	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightvarmod);
 
     public BiomeGenWasteland(int id)
     {

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenWasteland.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenWasteland.java
@@ -13,12 +13,12 @@ import biomesoplenty.common.configuration.BOPConfigurationMisc;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenDeadTree;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenWasteland extends BOPOverworldBiome implements IBiomeFog
 {
     //private static final Height biomeHeight = new Height(0.1F, 0.1F);
-	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightVarMod);
 
     public BiomeGenWasteland(int id)
     {

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenWetland.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenWetland.java
@@ -17,10 +17,13 @@ import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.WorldGenMoss;
 import biomesoplenty.common.world.features.trees.WorldGenBOPSwampTree;
 import biomesoplenty.common.world.features.trees.WorldGenBOPTaiga2;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenWetland extends BOPOverworldBiome
 {
-    private static final Height biomeHeight = new Height(-0.1F, 0.2F);
+    //private static final Height biomeHeight = new Height(-0.1F, 0.2F);
+	private static final Height biomeHeight = new Height(-0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.2F*BOPConfigurationTerrainGen.heightvarmod);
 
     public BiomeGenWetland(int id)
     {

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenWetland.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenWetland.java
@@ -18,12 +18,12 @@ import biomesoplenty.common.world.features.WorldGenMoss;
 import biomesoplenty.common.world.features.trees.WorldGenBOPSwampTree;
 import biomesoplenty.common.world.features.trees.WorldGenBOPTaiga2;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenWetland extends BOPOverworldBiome
 {
     //private static final Height biomeHeight = new Height(-0.1F, 0.2F);
-	private static final Height biomeHeight = new Height(-0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.2F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(-0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.2F*BOPConfigurationTerrainGen.heightVarMod);
 
     public BiomeGenWetland(int id)
     {

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenWoodland.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenWoodland.java
@@ -11,11 +11,14 @@ import biomesoplenty.api.content.BOPCBlocks;
 import biomesoplenty.common.biome.BOPOverworldBiome;
 import biomesoplenty.common.world.features.WorldGenBOPDoubleFlora;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenWoodland extends BOPOverworldBiome
 {
-    private static final Height biomeHeight = new Height(0.1F, 0.2F);
-    
+    //private static final Height biomeHeight = new Height(0.1F, 0.2F);
+ 	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.2F*BOPConfigurationTerrainGen.heightvarmod);
+   
 	public BiomeGenWoodland(int id)
 	{
 		super(id);

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenWoodland.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenWoodland.java
@@ -12,12 +12,12 @@ import biomesoplenty.common.biome.BOPOverworldBiome;
 import biomesoplenty.common.world.features.WorldGenBOPDoubleFlora;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenWoodland extends BOPOverworldBiome
 {
     //private static final Height biomeHeight = new Height(0.1F, 0.2F);
- 	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.2F*BOPConfigurationTerrainGen.heightvarmod);
+ 	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.2F*BOPConfigurationTerrainGen.heightVarMod);
    
 	public BiomeGenWoodland(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/ocean/BiomeGenCoralReef.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/ocean/BiomeGenCoralReef.java
@@ -7,11 +7,14 @@ import net.minecraft.init.Blocks;
 import net.minecraft.world.World;
 import biomesoplenty.api.content.BOPCBlocks;
 import biomesoplenty.common.biome.BOPOceanBiome;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenCoralReef extends BOPOceanBiome
 {
-    private static final Height biomeHeight = new Height(-0.6F, 0.1F);
-	
+    //private static final Height biomeHeight = new Height(-0.6F, 0.1F);
+	private static final Height biomeHeight = new Height(-0.6F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightvarmod);
+
 	public BiomeGenCoralReef(int biomeID) 
 	{
 		super(biomeID);

--- a/src/main/java/biomesoplenty/common/biome/overworld/ocean/BiomeGenCoralReef.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/ocean/BiomeGenCoralReef.java
@@ -8,12 +8,12 @@ import net.minecraft.world.World;
 import biomesoplenty.api.content.BOPCBlocks;
 import biomesoplenty.common.biome.BOPOceanBiome;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenCoralReef extends BOPOceanBiome
 {
     //private static final Height biomeHeight = new Height(-0.6F, 0.1F);
-	private static final Height biomeHeight = new Height(-0.6F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(-0.6F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightVarMod);
 
 	public BiomeGenCoralReef(int biomeID) 
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/ocean/BiomeGenKelpForest.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/ocean/BiomeGenKelpForest.java
@@ -8,12 +8,12 @@ import net.minecraft.world.World;
 import biomesoplenty.api.content.BOPCBlocks;
 import biomesoplenty.common.biome.BOPOceanBiome;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenKelpForest extends BOPOceanBiome
 {
     //private static final Height biomeHeight = new Height(-1.2F, 0.1F);
-	private static final Height biomeHeight = new Height(-1.2F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(-1.2F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightVarMod);
 	
 	public BiomeGenKelpForest(int biomeID)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/ocean/BiomeGenKelpForest.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/ocean/BiomeGenKelpForest.java
@@ -7,10 +7,13 @@ import net.minecraft.init.Blocks;
 import net.minecraft.world.World;
 import biomesoplenty.api.content.BOPCBlocks;
 import biomesoplenty.common.biome.BOPOceanBiome;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenKelpForest extends BOPOceanBiome
 {
-    private static final Height biomeHeight = new Height(-1.2F, 0.1F);
+    //private static final Height biomeHeight = new Height(-1.2F, 0.1F);
+	private static final Height biomeHeight = new Height(-1.2F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightvarmod);
 	
 	public BiomeGenKelpForest(int biomeID)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenAlpsForest.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenAlpsForest.java
@@ -10,10 +10,13 @@ import biomesoplenty.api.content.BOPCBlocks;
 import biomesoplenty.common.biome.BOPSubBiome;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBOPTaiga2;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenAlpsForest extends BOPSubBiome
 {
-	private static final Height biomeHeight = new Height(0.6F, 0.8F);
+	//private static final Height biomeHeight = new Height(0.6F, 0.8F);
+	private static final Height biomeHeight = new Height(0.6F*BOPConfigurationTerrainGen.heightrootmod, 0.8F*BOPConfigurationTerrainGen.heightvarmod);
 	
 	public BiomeGenAlpsForest(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenAlpsForest.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenAlpsForest.java
@@ -11,12 +11,12 @@ import biomesoplenty.common.biome.BOPSubBiome;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBOPTaiga2;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenAlpsForest extends BOPSubBiome
 {
 	//private static final Height biomeHeight = new Height(0.6F, 0.8F);
-	private static final Height biomeHeight = new Height(0.6F*BOPConfigurationTerrainGen.heightrootmod, 0.8F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(0.6F*BOPConfigurationTerrainGen.heightrootmod, 0.8F*BOPConfigurationTerrainGen.heightVarMod);
 	
 	public BiomeGenAlpsForest(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenCanyonRavine.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenCanyonRavine.java
@@ -12,12 +12,12 @@ import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBOPShrub;
 import biomesoplenty.common.world.features.trees.WorldGenPineTree;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenCanyonRavine extends BOPSubBiome
 {
 	//private static final Height biomeHeight = new Height(-0.1F, 0.4F);
-	private static final Height biomeHeight = new Height(-0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.4F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(-0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.4F*BOPConfigurationTerrainGen.heightVarMod);
 
 	public BiomeGenCanyonRavine(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenCanyonRavine.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenCanyonRavine.java
@@ -11,10 +11,13 @@ import biomesoplenty.common.biome.BOPSubBiome;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBOPShrub;
 import biomesoplenty.common.world.features.trees.WorldGenPineTree;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenCanyonRavine extends BOPSubBiome
 {
-	private static final Height biomeHeight = new Height(-0.1F, 0.4F);
+	//private static final Height biomeHeight = new Height(-0.1F, 0.4F);
+	private static final Height biomeHeight = new Height(-0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.4F*BOPConfigurationTerrainGen.heightvarmod);
 
 	public BiomeGenCanyonRavine(int id)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenGlacier.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenGlacier.java
@@ -9,12 +9,12 @@ import biomesoplenty.api.BOPBlockHelper;
 import biomesoplenty.api.content.BOPCBlocks;
 import biomesoplenty.common.biome.BOPSubBiome;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenGlacier extends BOPSubBiome
 {
 	//private static final Height biomeHeight = new Height(1.5F, 0.025F);
-	private static final Height biomeHeight = new Height(1.5F*BOPConfigurationTerrainGen.heightrootmod, 0.025F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(1.5F*BOPConfigurationTerrainGen.heightrootmod, 0.025F*BOPConfigurationTerrainGen.heightVarMod);
 	
 	public BiomeGenGlacier(int biomeID) 
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenGlacier.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenGlacier.java
@@ -8,10 +8,13 @@ import net.minecraft.world.World;
 import biomesoplenty.api.BOPBlockHelper;
 import biomesoplenty.api.content.BOPCBlocks;
 import biomesoplenty.common.biome.BOPSubBiome;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenGlacier extends BOPSubBiome
 {
-	private static final Height biomeHeight = new Height(1.5F, 0.025F);
+	//private static final Height biomeHeight = new Height(1.5F, 0.025F);
+	private static final Height biomeHeight = new Height(1.5F*BOPConfigurationTerrainGen.heightrootmod, 0.025F*BOPConfigurationTerrainGen.heightvarmod);
 	
 	public BiomeGenGlacier(int biomeID) 
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenMangrove.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenMangrove.java
@@ -11,10 +11,13 @@ import biomesoplenty.common.biome.BOPSubBiome;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBOPShrub;
 import biomesoplenty.common.world.features.trees.WorldGenMangrove;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenMangrove extends BOPSubBiome
 {
-    private static final Height biomeHeight = new Height(0.0F, 0.2F);
+    //private static final Height biomeHeight = new Height(0.0F, 0.2F);
+	private static final Height biomeHeight = new Height(0.0F*BOPConfigurationTerrainGen.heightrootmod, 0.2F*BOPConfigurationTerrainGen.heightvarmod);
 	
 	public BiomeGenMangrove(int biomeID) 
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenMangrove.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenMangrove.java
@@ -12,12 +12,12 @@ import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBOPShrub;
 import biomesoplenty.common.world.features.trees.WorldGenMangrove;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenMangrove extends BOPSubBiome
 {
     //private static final Height biomeHeight = new Height(0.0F, 0.2F);
-	private static final Height biomeHeight = new Height(0.0F*BOPConfigurationTerrainGen.heightrootmod, 0.2F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(0.0F*BOPConfigurationTerrainGen.heightrootmod, 0.2F*BOPConfigurationTerrainGen.heightVarMod);
 	
 	public BiomeGenMangrove(int biomeID) 
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenMeadowForest.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenMeadowForest.java
@@ -12,6 +12,8 @@ import biomesoplenty.common.biome.BOPSubBiome;
 import biomesoplenty.common.world.features.WorldGenBOPFlora;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBOPTaiga2;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenMeadowForest extends BOPSubBiome
 {

--- a/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenMeadowForest.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenMeadowForest.java
@@ -13,7 +13,7 @@ import biomesoplenty.common.world.features.WorldGenBOPFlora;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBOPTaiga2;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenMeadowForest extends BOPSubBiome
 {

--- a/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenOasis.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenOasis.java
@@ -10,10 +10,13 @@ import biomesoplenty.api.content.BOPCBlocks;
 import biomesoplenty.common.biome.BOPSubBiome;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenPalmTree1;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenOasis extends BOPSubBiome
 {
-	private static final Height biomeHeight = new Height(-0.2F, 0.0F);
+	//private static final Height biomeHeight = new Height(-0.2F, 0.0F);
+	private static final Height biomeHeight = new Height(-0.2F*BOPConfigurationTerrainGen.heightrootmod, 0.0F*BOPConfigurationTerrainGen.heightvarmod);
 	
 	public BiomeGenOasis(int biomeID)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenOasis.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenOasis.java
@@ -11,12 +11,12 @@ import biomesoplenty.common.biome.BOPSubBiome;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenPalmTree1;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenOasis extends BOPSubBiome
 {
 	//private static final Height biomeHeight = new Height(-0.2F, 0.0F);
-	private static final Height biomeHeight = new Height(-0.2F*BOPConfigurationTerrainGen.heightrootmod, 0.0F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(-0.2F*BOPConfigurationTerrainGen.heightrootmod, 0.0F*BOPConfigurationTerrainGen.heightVarMod);
 	
 	public BiomeGenOasis(int biomeID)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenOrchard.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenOrchard.java
@@ -14,10 +14,13 @@ import biomesoplenty.common.biome.BOPSubBiome;
 import biomesoplenty.common.world.features.WorldGenBOPDoubleFlora;
 import biomesoplenty.common.world.features.WorldGenBOPFlora;
 import biomesoplenty.common.world.features.trees.WorldGenOriginalTree;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenOrchard extends BOPSubBiome
 {
-	private static final Height biomeHeight = new Height(0.1F, 0.1F);
+	//private static final Height biomeHeight = new Height(0.1F, 0.1F);
+	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightvarmod);
 	
 	public BiomeGenOrchard(int biomeID) 
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenOrchard.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenOrchard.java
@@ -15,12 +15,12 @@ import biomesoplenty.common.world.features.WorldGenBOPDoubleFlora;
 import biomesoplenty.common.world.features.WorldGenBOPFlora;
 import biomesoplenty.common.world.features.trees.WorldGenOriginalTree;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenOrchard extends BOPSubBiome
 {
 	//private static final Height biomeHeight = new Height(0.1F, 0.1F);
-	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightVarMod);
 	
 	public BiomeGenOrchard(int biomeID) 
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenQuagmire.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenQuagmire.java
@@ -12,12 +12,12 @@ import biomesoplenty.common.configuration.BOPConfigurationMisc;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenDeadTree;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenQuagmire extends BOPSubBiome
 {
     //private static final Height biomeHeight = new Height(0.0F, 0.1F);
- 	private static final Height biomeHeight = new Height(0.0F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightvarmod);
+ 	private static final Height biomeHeight = new Height(0.0F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightVarMod);
    
     public BiomeGenQuagmire(int id)
     {

--- a/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenQuagmire.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenQuagmire.java
@@ -11,11 +11,14 @@ import biomesoplenty.common.biome.BOPSubBiome;
 import biomesoplenty.common.configuration.BOPConfigurationMisc;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenDeadTree;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenQuagmire extends BOPSubBiome
 {
-    private static final Height biomeHeight = new Height(0.0F, 0.1F);
-    
+    //private static final Height biomeHeight = new Height(0.0F, 0.1F);
+ 	private static final Height biomeHeight = new Height(0.0F*BOPConfigurationTerrainGen.heightrootmod, 0.1F*BOPConfigurationTerrainGen.heightvarmod);
+   
     public BiomeGenQuagmire(int id)
     {
         super(id);

--- a/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenScrubland.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenScrubland.java
@@ -13,12 +13,12 @@ import biomesoplenty.common.world.features.WorldGenBOPDoubleFlora;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenOriginalTree;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenScrubland extends BOPSubBiome
 {
 	//private static final Height biomeHeight = new Height(0.125F, 0.05F);
-	private static final Height biomeHeight = new Height(0.125F*BOPConfigurationTerrainGen.heightrootmod, 0.05F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(0.125F*BOPConfigurationTerrainGen.heightrootmod, 0.05F*BOPConfigurationTerrainGen.heightVarMod);
 
 	public BiomeGenScrubland(int biomeID)
 	{

--- a/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenScrubland.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenScrubland.java
@@ -12,11 +12,14 @@ import biomesoplenty.common.biome.BOPSubBiome;
 import biomesoplenty.common.world.features.WorldGenBOPDoubleFlora;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenOriginalTree;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenScrubland extends BOPSubBiome
 {
-	private static final Height biomeHeight = new Height(0.125F, 0.05F);
-	
+	//private static final Height biomeHeight = new Height(0.125F, 0.05F);
+	private static final Height biomeHeight = new Height(0.125F*BOPConfigurationTerrainGen.heightrootmod, 0.05F*BOPConfigurationTerrainGen.heightvarmod);
+
 	public BiomeGenScrubland(int biomeID)
 	{
 		super(biomeID);

--- a/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenSilkglades.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenSilkglades.java
@@ -14,12 +14,12 @@ import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBOPSwampTree;
 import biomesoplenty.common.world.features.trees.WorldGenDeadTree;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenSilkglades extends BOPSubBiome
 {
     //private static final Height biomeHeight = new Height(0.1F, 0.2F);
-	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.2F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.2F*BOPConfigurationTerrainGen.heightVarMod);
 
     public BiomeGenSilkglades(int id)
     {

--- a/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenSilkglades.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenSilkglades.java
@@ -13,10 +13,13 @@ import biomesoplenty.common.configuration.BOPConfigurationMisc;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBOPSwampTree;
 import biomesoplenty.common.world.features.trees.WorldGenDeadTree;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenSilkglades extends BOPSubBiome
 {
-    private static final Height biomeHeight = new Height(0.1F, 0.2F);
+    //private static final Height biomeHeight = new Height(0.1F, 0.2F);
+	private static final Height biomeHeight = new Height(0.1F*BOPConfigurationTerrainGen.heightrootmod, 0.2F*BOPConfigurationTerrainGen.heightvarmod);
 
     public BiomeGenSilkglades(int id)
     {

--- a/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenSpruceWoods.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenSpruceWoods.java
@@ -13,6 +13,8 @@ import biomesoplenty.common.biome.BOPSubBiome;
 import biomesoplenty.common.world.features.WorldGenBOPFlora;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBOPTaiga2;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenSpruceWoods extends BOPSubBiome
 {

--- a/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenSpruceWoods.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenSpruceWoods.java
@@ -14,7 +14,7 @@ import biomesoplenty.common.world.features.WorldGenBOPFlora;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBOPTaiga2;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenSpruceWoods extends BOPSubBiome
 {

--- a/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenTropics.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenTropics.java
@@ -17,12 +17,12 @@ import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenPalmTree1;
 import biomesoplenty.common.world.features.trees.WorldGenTropicsShrub;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenTropics extends BOPSubBiome
 {
     //private static final Height biomeHeight = new Height(0.2F, 0.3F);
-	private static final Height biomeHeight = new Height(0.2F*BOPConfigurationTerrainGen.heightrootmod, 0.3F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(0.2F*BOPConfigurationTerrainGen.heightrootmod, 0.3F*BOPConfigurationTerrainGen.heightVarMod);
 
     public BiomeGenTropics(int id)
     {

--- a/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenTropics.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenTropics.java
@@ -16,10 +16,13 @@ import biomesoplenty.common.world.features.WorldGenBOPFlora;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenPalmTree1;
 import biomesoplenty.common.world.features.trees.WorldGenTropicsShrub;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenTropics extends BOPSubBiome
 {
-    private static final Height biomeHeight = new Height(0.2F, 0.3F);
+    //private static final Height biomeHeight = new Height(0.2F, 0.3F);
+	private static final Height biomeHeight = new Height(0.2F*BOPConfigurationTerrainGen.heightrootmod, 0.3F*BOPConfigurationTerrainGen.heightvarmod);
 
     public BiomeGenTropics(int id)
     {

--- a/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenVolcano.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenVolcano.java
@@ -8,10 +8,13 @@ import net.minecraft.world.World;
 import biomesoplenty.api.content.BOPCBlocks;
 import biomesoplenty.common.biome.BOPSubBiome;
 import biomesoplenty.common.configuration.BOPConfigurationMisc;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenVolcano extends BOPSubBiome
 {
-    private static final Height biomeHeight = new Height(2.5F, 0.5F);
+    //private static final Height biomeHeight = new Height(2.5F, 0.5F);
+	private static final Height biomeHeight = new Height(2.5F*BOPConfigurationTerrainGen.heightrootmod, 0.5F*BOPConfigurationTerrainGen.heightvarmod);
 
     public BiomeGenVolcano(int id)
     {

--- a/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenVolcano.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/sub/BiomeGenVolcano.java
@@ -9,12 +9,12 @@ import biomesoplenty.api.content.BOPCBlocks;
 import biomesoplenty.common.biome.BOPSubBiome;
 import biomesoplenty.common.configuration.BOPConfigurationMisc;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenVolcano extends BOPSubBiome
 {
     //private static final Height biomeHeight = new Height(2.5F, 0.5F);
-	private static final Height biomeHeight = new Height(2.5F*BOPConfigurationTerrainGen.heightrootmod, 0.5F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(2.5F*BOPConfigurationTerrainGen.heightrootmod, 0.5F*BOPConfigurationTerrainGen.heightVarMod);
 
     public BiomeGenVolcano(int id)
     {

--- a/src/main/java/biomesoplenty/common/biome/overworld/tech/BiomeGenDryRiver.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/tech/BiomeGenDryRiver.java
@@ -4,12 +4,12 @@ import net.minecraft.init.Blocks;
 import biomesoplenty.api.biome.BOPBiome;
 import biomesoplenty.common.biome.BOPOverworldBiome;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenDryRiver extends BOPOverworldBiome
 {
 	//private static final Height biomeHeight = new Height(-0.2F, 0.0F);
-	private static final Height biomeHeight = new Height(-0.2F*BOPConfigurationTerrainGen.heightrootmod, 0.0F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(-0.2F*BOPConfigurationTerrainGen.heightrootmod, 0.0F*BOPConfigurationTerrainGen.heightVarMod);
 
     public BiomeGenDryRiver(int biomeId)
     {

--- a/src/main/java/biomesoplenty/common/biome/overworld/tech/BiomeGenDryRiver.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/tech/BiomeGenDryRiver.java
@@ -3,10 +3,13 @@ package biomesoplenty.common.biome.overworld.tech;
 import net.minecraft.init.Blocks;
 import biomesoplenty.api.biome.BOPBiome;
 import biomesoplenty.common.biome.BOPOverworldBiome;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenDryRiver extends BOPOverworldBiome
 {
-	private static final Height biomeHeight = new Height(-0.2F, 0.0F);
+	//private static final Height biomeHeight = new Height(-0.2F, 0.0F);
+	private static final Height biomeHeight = new Height(-0.2F*BOPConfigurationTerrainGen.heightrootmod, 0.0F*BOPConfigurationTerrainGen.heightvarmod);
 
     public BiomeGenDryRiver(int biomeId)
     {

--- a/src/main/java/biomesoplenty/common/biome/overworld/tech/BiomeGenLushRiver.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/tech/BiomeGenLushRiver.java
@@ -9,10 +9,13 @@ import biomesoplenty.api.content.BOPCBlocks;
 import biomesoplenty.common.biome.BOPOverworldBiome;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBOPShrub;
+import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
 
 public class BiomeGenLushRiver extends BOPOverworldBiome
 {
-	private static final Height biomeHeight = new Height(-0.5F, 0.0F);
+	//private static final Height biomeHeight = new Height(-0.5F, 0.0F);
+	private static final Height biomeHeight = new Height(-0.5F*BOPConfigurationTerrainGen.heightrootmod, 0.0F*BOPConfigurationTerrainGen.heightvarmod);
 
     public BiomeGenLushRiver(int par1)
     {

--- a/src/main/java/biomesoplenty/common/biome/overworld/tech/BiomeGenLushRiver.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/tech/BiomeGenLushRiver.java
@@ -10,12 +10,12 @@ import biomesoplenty.common.biome.BOPOverworldBiome;
 import biomesoplenty.common.world.features.WorldGenBOPTallGrass;
 import biomesoplenty.common.world.features.trees.WorldGenBOPShrub;
 import biomesoplenty.common.configuration.BOPConfigurationTerrainGen;
-// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightvarmod
+// BOPConfigurationTerrainGen.heightrootmod - BOPConfigurationTerrainGen.heightVarMod
 
 public class BiomeGenLushRiver extends BOPOverworldBiome
 {
 	//private static final Height biomeHeight = new Height(-0.5F, 0.0F);
-	private static final Height biomeHeight = new Height(-0.5F*BOPConfigurationTerrainGen.heightrootmod, 0.0F*BOPConfigurationTerrainGen.heightvarmod);
+	private static final Height biomeHeight = new Height(-0.5F*BOPConfigurationTerrainGen.heightrootmod, 0.0F*BOPConfigurationTerrainGen.heightVarMod);
 
     public BiomeGenLushRiver(int par1)
     {

--- a/src/main/java/biomesoplenty/common/configuration/BOPConfigurationTerrainGen.java
+++ b/src/main/java/biomesoplenty/common/configuration/BOPConfigurationTerrainGen.java
@@ -20,6 +20,8 @@ public class BOPConfigurationTerrainGen
 	
 	public static boolean oceanFiller;
 	public static int landmassPercentage;
+        public static int heightrootmod;
+        public static int heightvarmod;
 
 	public static void init(File configFile)
 	{
@@ -36,6 +38,8 @@ public class BOPConfigurationTerrainGen
 			
 			oceanFiller = config.get("Biomes O\' Plenty World Type Settings", "OceanFiller", true, "Fills the ocean with land biomes if there is an excessive amount. This must be disabled to use the landmass percentage").getBoolean();
 			landmassPercentage = config.get("Biomes O\' Plenty World Type Settings", "Landmass Percentage", 10, "Requires ocean filler to be disabled. In Vanilla it is set to 10. Takes values from 0 to 100.").getInt();
+			heightrootmod = config.get("Biomes O\' Plenty World Type Settings", "Height Root Mod", 1, "Value to multiple all biome height root values by. Defaults to 1.").getInt();
+			heightvarmod = config.get("Biomes O\' Plenty World Type Settings", "Height Var Mod", 1, "Value to multiple all biome height variance values by. Defaults to 1.").getInt();
 		}
 		catch (Exception e)
 		{

--- a/src/main/java/biomesoplenty/common/configuration/BOPConfigurationTerrainGen.java
+++ b/src/main/java/biomesoplenty/common/configuration/BOPConfigurationTerrainGen.java
@@ -21,7 +21,7 @@ public class BOPConfigurationTerrainGen
 	public static boolean oceanFiller;
 	public static int landmassPercentage;
         public static int heightrootmod;
-        public static int heightvarmod;
+        public static int heightVarMod;
 
 	public static void init(File configFile)
 	{
@@ -39,7 +39,7 @@ public class BOPConfigurationTerrainGen
 			oceanFiller = config.get("Biomes O\' Plenty World Type Settings", "OceanFiller", true, "Fills the ocean with land biomes if there is an excessive amount. This must be disabled to use the landmass percentage").getBoolean();
 			landmassPercentage = config.get("Biomes O\' Plenty World Type Settings", "Landmass Percentage", 10, "Requires ocean filler to be disabled. In Vanilla it is set to 10. Takes values from 0 to 100.").getInt();
 			heightrootmod = config.get("Biomes O\' Plenty World Type Settings", "Height Root Mod", 1, "Value to multiple all biome height root values by. Defaults to 1.").getInt();
-			heightvarmod = config.get("Biomes O\' Plenty World Type Settings", "Height Var Mod", 1, "Value to multiple all biome height variance values by. Defaults to 1.").getInt();
+			heightVarMod = config.get("Biomes O\' Plenty World Type Settings", "Height Var Mod", 1, "Value to multiple all biome height variance values by. Defaults to 1.").getInt();
 		}
 		catch (Exception e)
 		{


### PR DESCRIPTION
Added the following to terraingen.cfg:

    # Multiplier for biome world gen height variables. 
    I:heightRootMod=1
    I:heightVarMod=5

This allows users to create biomes similar to what they would see with an "amplified" configuration. The configurable variables act as multipliers to the two height variables used during biome creation. The default multiplier is 1x, which acts the same was as initially coded. This satisfies the frequent request from users to allow amplified biome creation without a hack or unauthorized fork after that video Etho made.