### PR TITLE
Scale fog density to far plane distance.

### DIFF
--- a/src/main/java/biomesoplenty/client/fog/FogHandler.java
+++ b/src/main/java/biomesoplenty/client/fog/FogHandler.java
@@ -117,7 +117,7 @@ public class FogHandler
 		float weightMixed = (distance * 2) * (distance * 2);
 		float weightDefault = weightMixed - weightBiomeFog;
 
-		float farPlaneDistance = (fpDistanceBiomeFog + event.farPlaneDistance * weightDefault) / weightMixed;
+		float farPlaneDistance = (fpDistanceBiomeFog * 240 + event.farPlaneDistance * weightDefault) / weightMixed;
 		float farPlaneDistanceScale = (0.25f * weightBiomeFog + 0.75f * weightDefault) / weightMixed;
 
 		fogX = entity.posX;

--- a/src/main/java/biomesoplenty/common/biome/nether/BiomeGenPolarChasm.java
+++ b/src/main/java/biomesoplenty/common/biome/nether/BiomeGenPolarChasm.java
@@ -26,6 +26,6 @@ public class BiomeGenPolarChasm extends BOPNetherBiome implements IBiomeFog
 
     public float getFogDensity(int x, int y, int z)
     {
-        return 0.01F;
+        return 0.99F;
     }
 }

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenBambooForest.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenBambooForest.java
@@ -104,7 +104,6 @@ public class BiomeGenBambooForest extends BOPOverworldBiome implements IBiomeFog
 
     public float getFogDensity(int x, int y, int z)
     {
-        // TODO Auto-generated method stub
-        return 0.01F;
+        return 0.99F;
     }
 }

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenOminousWoods.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenOminousWoods.java
@@ -125,6 +125,6 @@ public class BiomeGenOminousWoods extends BOPOverworldBiome implements IBiomeFog
     @Override
     public float getFogDensity(int x, int y, int z)
     {
-        return 10F;
+        return 0.1f;
     }
 }

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenTropicalRainforest.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenTropicalRainforest.java
@@ -119,6 +119,6 @@ public class BiomeGenTropicalRainforest extends BOPOverworldBiome implements IBi
 
     public float getFogDensity(int x, int y, int z)
     {
-        return 0.01F;
+        return 0.99F;
     }
 }


### PR DESCRIPTION
This should make the fog usable in biomes now.  The 3 biomes with 0.01 fog densities have been switched to 0.99, since that seemed like the real intention.