### PR TITLE
Fix fog render and add configuration

### DIFF
--- a/src/main/java/biomesoplenty/client/fog/FogHandler.java
+++ b/src/main/java/biomesoplenty/client/fog/FogHandler.java
@@ -1,5 +1,6 @@
 package biomesoplenty.client.fog;
 
+import biomesoplenty.common.configuration.BOPConfigurationMisc;
 import cpw.mods.fml.common.eventhandler.Event;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
@@ -28,6 +29,11 @@ public class FogHandler
 	@SubscribeEvent
 	public void onGetFogColour(FogColors event)
 	{
+		if (!BOPConfigurationMisc.fogColors)
+		{
+			return;
+		}
+
 		if (event.entity instanceof EntityPlayer)
 		{
 			EntityPlayer player = (EntityPlayer)event.entity;
@@ -52,6 +58,11 @@ public class FogHandler
 	@SubscribeEvent
 	public void onRenderFog(EntityViewRenderEvent.RenderFogEvent event)
 	{
+		if (!BOPConfigurationMisc.fogDensity)
+		{
+			return;
+		}
+
 		Entity entity = event.entity;
         World world = entity.worldObj;
         

--- a/src/main/java/biomesoplenty/client/fog/FogHandler.java
+++ b/src/main/java/biomesoplenty/client/fog/FogHandler.java
@@ -117,8 +117,11 @@ public class FogHandler
 		float weightMixed = (distance * 2) * (distance * 2);
 		float weightDefault = weightMixed - weightBiomeFog;
 
+		float fpDistanceBiomeFogAvg = (weightBiomeFog == 0) ? 0 : fpDistanceBiomeFog / weightBiomeFog;
+
 		float farPlaneDistance = (fpDistanceBiomeFog * 240 + event.farPlaneDistance * weightDefault) / weightMixed;
-		float farPlaneDistanceScale = (0.25f * weightBiomeFog + 0.75f * weightDefault) / weightMixed;
+		float farPlaneDistanceScaleBiome = (0.1f * (1 - fpDistanceBiomeFogAvg) + 0.75f * fpDistanceBiomeFogAvg);
+		float farPlaneDistanceScale = (farPlaneDistanceScaleBiome * weightBiomeFog + 0.75f * weightDefault) / weightMixed;
 
 		fogX = entity.posX;
 		fogZ = entity.posZ;

--- a/src/main/java/biomesoplenty/client/fog/FogHandler.java
+++ b/src/main/java/biomesoplenty/client/fog/FogHandler.java
@@ -58,11 +58,6 @@ public class FogHandler
 	@SubscribeEvent
 	public void onRenderFog(EntityViewRenderEvent.RenderFogEvent event)
 	{
-		if (!BOPConfigurationMisc.fogDensity)
-		{
-			return;
-		}
-
 		Entity entity = event.entity;
         World world = entity.worldObj;
         

--- a/src/main/java/biomesoplenty/common/configuration/BOPConfigurationMisc.java
+++ b/src/main/java/biomesoplenty/common/configuration/BOPConfigurationMisc.java
@@ -11,12 +11,10 @@ public class BOPConfigurationMisc
 	public static Configuration config;
 	
 	public static boolean skyColors;
+	public static boolean fogColors;
 	//public static boolean achievements;
 	public static boolean dungeonLoot;
 	public static boolean titlePanorama;
-
-	public static boolean fogColors;
-	public static boolean fogDensity;
 
     public static boolean hotSpringsRegeneration;
 	
@@ -39,9 +37,7 @@ public class BOPConfigurationMisc
 
 			//Hard-Coded Colors
 			skyColors = config.get("Hard-Coded Colors", "Enable Sky Colors", true).getBoolean(false);
-
-			fogColors = config.get("Fog Settings", "Enable Fog Colors", true).getBoolean(false);
-			fogDensity = config.get("Fog Settings", "Enable Fog Density", true).getBoolean(false);
+			fogColors = config.get("Hard-Coded Colors", "Enable Fog Colors", true).getBoolean(false);
 			
 			spawnSearchRadius = config.get("Spawn Settings", "Spawn Location Search Radius", 1024, "Must be 256 or higher").getInt();
 			if (spawnSearchRadius < 256) spawnSearchRadius = 256;

--- a/src/main/java/biomesoplenty/common/configuration/BOPConfigurationMisc.java
+++ b/src/main/java/biomesoplenty/common/configuration/BOPConfigurationMisc.java
@@ -15,6 +15,9 @@ public class BOPConfigurationMisc
 	public static boolean dungeonLoot;
 	public static boolean titlePanorama;
 
+	public static boolean fogColors;
+	public static boolean fogDensity;
+
     public static boolean hotSpringsRegeneration;
 	
 	public static int spawnSearchRadius;
@@ -36,6 +39,9 @@ public class BOPConfigurationMisc
 
 			//Hard-Coded Colors
 			skyColors = config.get("Hard-Coded Colors", "Enable Sky Colors", true).getBoolean(false);
+
+			fogColors = config.get("Fog Settings", "Enable Fog Colors", true).getBoolean(false);
+			fogDensity = config.get("Fog Settings", "Enable Fog Density", true).getBoolean(false);
 			
 			spawnSearchRadius = config.get("Spawn Settings", "Spawn Location Search Radius", 1024, "Must be 256 or higher").getInt();
 			if (spawnSearchRadius < 256) spawnSearchRadius = 256;


### PR DESCRIPTION
This fixes an oversight I made when moving the near-plane distance closer to enhance dense fog biomes, causing haziness in biomes which shouldn't have closer fog.

This sets the near plane distance between 0.1 and 0.75 (vanilla) of the far plane distance based on the 0.0 - 1.0 fog density of the biome.

I also added two boolean config properties to toggle the fog color and density, since the restoration of this feature may not be welcome by all players or packs.