### PR TITLE
Avoid NPE in the fuel handler

### DIFF
--- a/src/main/java/biomesoplenty/common/handlers/FurnaceFuelHandler.java
+++ b/src/main/java/biomesoplenty/common/handlers/FurnaceFuelHandler.java
@@ -71,6 +71,7 @@ public class FurnaceFuelHandler implements IFuelHandler
 	
 private static int getFuelValue(ItemStack stack)
 {
+	if ( (stack==null) || (stack.getItem()==null) ) return 0;
     Pair<Item, Integer> pair = Pair.of(stack.getItem(), stack.getItemDamage());
 
     if (fuelList.containsKey(pair))


### PR DESCRIPTION
Passing a badly implemented itemstack (the stack for some reason returns null for getItem) is passed the game will crash with a NPE.

Here is an example crash report: http://pastebin.com/K0vpKQ6N 