### PR TITLE
Fixed #442

### DIFF
--- a/src/main/java/biomesoplenty/common/blocks/BlockBOPNewGrass.java
+++ b/src/main/java/biomesoplenty/common/blocks/BlockBOPNewGrass.java
@@ -212,6 +212,7 @@ public class BlockBOPNewGrass extends BlockGrass implements ISubLocalization
 	@SideOnly(Side.CLIENT)
     public IIcon getIcon(int side, int meta)
     {
+    	if (meta > grassTypes.length-1) meta = 0;
         return side == 1 ? Blocks.grass.getIcon(side, meta) : side == 0 ? BOPCBlocks.newBopDirt.getIcon(side, meta * 2) : grassIcons[2 * meta];
     }
     
@@ -220,6 +221,7 @@ public class BlockBOPNewGrass extends BlockGrass implements ISubLocalization
     public IIcon getIcon(IBlockAccess world, int x, int y, int z, int side)
     {
     	int meta = world.getBlockMetadata(x, y, z);
+    	if (meta > grassTypes.length-1) meta = 0;
     	
     	if (side == 0)
     	{


### PR DESCRIPTION
Added limits to meta to prevent ArrayIndexOutOfBoundsException similar to BlockBOPNewDirt.java. 
Still probably a deeper issue here, but this will prevent crashes for now