### PR TITLE
Fixed #433

### DIFF
--- a/src/main/java/biomesoplenty/common/blocks/BlockBOPNewGrass.java
+++ b/src/main/java/biomesoplenty/common/blocks/BlockBOPNewGrass.java
@@ -173,12 +173,6 @@ public class BlockBOPNewGrass extends BlockGrass implements ISubLocalization
 		return baseName + "." + grassTypes[itemStack.getItemDamage()];
 	}
 	
-    @Override
-	public boolean renderAsNormalBlock()
-    {
-        return false;
-    }
-	
 	@Override
 	public int getRenderType()
 	{


### PR DESCRIPTION
Removed renderAsNormalBlock returning false to allow beds, torches, and monsters to spawn. Tested that block still renders the grass correctly.