### PR TITLE
Fixes issue #495

### DIFF
--- a/src/main/java/biomesoplenty/common/items/ItemBOPBucket.java
+++ b/src/main/java/biomesoplenty/common/items/ItemBOPBucket.java
@@ -55,9 +55,9 @@ public class ItemBOPBucket extends ItemFluidContainer
         	if(tile != null && tile instanceof IFluidHandler)
         	{
         		IFluidHandler tank = (IFluidHandler)tile;
-        		if(tank.fill(null,this.getFluid(itemStack), false) == this.getCapacity(itemStack))
+        		if(tank.fill(ForgeDirection.UNKNOWN,this.getFluid(itemStack), false) == this.getCapacity(itemStack))
         		{
-        			tank.fill(null,this.getFluid(itemStack), true);
+        			tank.fill(ForgeDirection.UNKNOWN,this.getFluid(itemStack), true);
         			if(!player.capabilities.isCreativeMode)
         				return new ItemStack(Items.bucket);
         		}


### PR DESCRIPTION
Currently the null value here is causing a client crash in 1.7.10. This happens when right-clicking both COFH portable tanks and BC pipes with a BOP bucket. Suggest using ForgeDirection.UNKNOWN instead.