### PR TITLE
Register biome essence recipe Fixes #230

### DIFF
--- a/src/main/java/biomesoplenty/common/blocks/BlockBOPSapling.java
+++ b/src/main/java/biomesoplenty/common/blocks/BlockBOPSapling.java
@@ -136,7 +136,7 @@ public class BlockBOPSapling extends BlockSapling
 			switch (meta)
 			{
 			case 0: // Apple Tree
-				obj = new WorldGenOriginalTree(Blocks.log, Blocks.leaves, 0, 0, 1);
+				obj = new WorldGenOriginalTree(Blocks.log, BOPCBlocks.appleLeaves, 0, 0, 1);
 				break;
 
 			case 1: // Autumn Tree
@@ -206,7 +206,7 @@ public class BlockBOPSapling extends BlockSapling
 				break;
 
 			case 15: // Persimmon
-				obj = new WorldGenOriginalTree(Blocks.log, BOPCBlocks.leaves2, 0, 0, 1);
+				obj = new WorldGenOriginalTree(Blocks.log, BOPCBlocks.persimmonLeaves, 0, 0, 1);
 				break;
 			}
 		}

--- a/src/main/java/biomesoplenty/common/recipes/BiomeEssenceRecipe.java
+++ b/src/main/java/biomesoplenty/common/recipes/BiomeEssenceRecipe.java
@@ -5,11 +5,16 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
+import net.minecraftforge.oredict.RecipeSorter;
 import biomesoplenty.api.BOPItemHelper;
 import biomesoplenty.api.content.BOPCItems;
 
 public class BiomeEssenceRecipe implements IRecipe
 {
+	static {
+		RecipeSorter.register("BiomesOPlenty:biomeessenceRecipe", BiomeEssenceRecipe.class, RecipeSorter.Category.SHAPELESS, "after:minecraft:shapeless");
+	}
+
     private ItemStack recipeOutput;
     
     @Override


### PR DESCRIPTION
Fixes #230 and also fixed missing apple and persimmon leaves. Why not to use them if they have textures and already implemented? Might be just an oversight. @Adubbz if you need to change something just say.