### PR TITLE
Patch 5

### DIFF
--- a/src/main/java/biomesoplenty/common/blocks/BOPBlock.java
+++ b/src/main/java/biomesoplenty/common/blocks/BOPBlock.java
@@ -33,7 +33,8 @@ public abstract class BOPBlock extends Block
     @Override
     public boolean canReplace(World world, int x, int y, int z, int side, ItemStack itemStack)
     {
-    	return this.canBlockStay(world, x, y, z, itemStack.getItemDamage());
+    	int metadata = itemStack != null ? itemStack.getItemDamage() : 0;
+    	return this.canBlockStay(world, x, y, z, metadata);
     } 
     
     @Override

--- a/src/main/java/biomesoplenty/common/blocks/BlockBOPColorizedSapling.java
+++ b/src/main/java/biomesoplenty/common/blocks/BlockBOPColorizedSapling.java
@@ -42,7 +42,8 @@ public class BlockBOPColorizedSapling extends BlockSapling
     @Override
     public boolean canReplace(World world, int x, int y, int z, int side, ItemStack itemStack)
     {
-    	return this.canPlaceBlockAt(world, x, y, z) && this.isValidPosition(world, x, y, z, itemStack.getItemDamage());
+    	int metadata = itemStack != null ? itemStack.getItemDamage() : 0;
+    	return this.canPlaceBlockAt(world, x, y, z) && this.isValidPosition(world, x, y, z, metadata);
     } 
     
     /**

--- a/src/main/java/biomesoplenty/common/blocks/BlockBOPCoral.java
+++ b/src/main/java/biomesoplenty/common/blocks/BlockBOPCoral.java
@@ -76,7 +76,8 @@ public class BlockBOPCoral extends BOPBlock
     @Override
 	public boolean canReplace(World world, int x, int y, int z, int side, ItemStack itemStack)
     {
-    	return world.getBlock(x, y + 1, z) == Blocks.water && this.canBlockStay(world, x, y, z, itemStack.getItemDamage());
+    	int metadata = itemStack != null ? itemStack.getItemDamage() : 0;
+    	return world.getBlock(x, y + 1, z) == Blocks.water && this.canBlockStay(world, x, y, z, metadata);
     }
     
 	@Override

--- a/src/main/java/biomesoplenty/common/blocks/BlockBOPFruit.java
+++ b/src/main/java/biomesoplenty/common/blocks/BlockBOPFruit.java
@@ -104,7 +104,7 @@ public class BlockBOPFruit extends BOPBlockWorldDecor
 	@Override
     public boolean canReplace(World world, int x, int y, int z, int side, ItemStack itemStack)
 	{
-		int metadata = itemStack.getItemDamage();
+		int metadata = itemStack != null ? itemStack.getItemDamage() : 0;
 		
         return this.isValidPosition(world, x, y, z, metadata);
 	}

--- a/src/main/java/biomesoplenty/common/blocks/BlockBOPPlant.java
+++ b/src/main/java/biomesoplenty/common/blocks/BlockBOPPlant.java
@@ -183,7 +183,7 @@ public class BlockBOPPlant extends BOPBlockWorldDecor implements IShearable
 	@Override
     public boolean canReplace(World world, int x, int y, int z, int side, ItemStack itemStack)
 	{
-		int metadata = itemStack.getItemDamage();
+		int metadata = itemStack != null ? itemStack.getItemDamage() : 0;
 		
         if (metadata == 5 || metadata == 13 || metadata == 15)
         	return this.isValidPosition(world, x, y, z, metadata);

--- a/src/main/java/biomesoplenty/common/blocks/BlockBOPSapling.java
+++ b/src/main/java/biomesoplenty/common/blocks/BlockBOPSapling.java
@@ -72,7 +72,8 @@ public class BlockBOPSapling extends BlockSapling
 	@Override
 	public boolean canReplace(World world, int x, int y, int z, int side, ItemStack itemStack)
 	{
-		return this.canPlaceBlockAt(world, x, y, z) && this.isValidPosition(world, x, y, z, itemStack.getItemDamage());
+		int metadata = itemStack != null ? itemStack.getItemDamage() : 0;
+		return this.canPlaceBlockAt(world, x, y, z) && this.isValidPosition(world, x, y, z, metadata);
 	} 
 	
 	/**

--- a/src/main/java/biomesoplenty/common/blocks/BlockStoneFormations.java
+++ b/src/main/java/biomesoplenty/common/blocks/BlockStoneFormations.java
@@ -110,7 +110,8 @@ public class BlockStoneFormations extends BOPBlockWorldDecor implements ISubLoca
 	@Override
     public boolean canReplace(World world, int x, int y, int z, int side, ItemStack itemStack)
 	{
-		return isValidPosition(world, x, y, z, itemStack.getItemDamage());
+		int metadata = itemStack != null ? itemStack.getItemDamage() : 0;
+		return isValidPosition(world, x, y, z, metadata);
 	}
 	
 	@Override


### PR DESCRIPTION
Handle null ItemStack in canReplace. Fixes #519 and #529 