### PR TITLE
Return null dropped metadata from giant flowers

### DIFF
--- a/src/main/java/biomesoplenty/common/blocks/BlockBOPPetals.java
+++ b/src/main/java/biomesoplenty/common/blocks/BlockBOPPetals.java
@@ -75,7 +75,7 @@ public class BlockBOPPetals extends BlockLeavesBase implements IShearable
 	@Override
 	public int damageDropped(int meta)
 	{
-		return meta & 15;
+		return 0;
 	}
 
 	@Override


### PR DESCRIPTION
Because it makes non-usable flowers in recipes..

![645465465](https://cloud.githubusercontent.com/assets/8511068/12865941/c68fccec-cce6-11e5-87f1-1df42614087b.png)

