### PR TITLE
Fixed BoP crashing on newer version of Forge Closes #773

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,4 +1,4 @@
 minecraft_version=1.9.4
-forge_version=12.17.0.1909-1.9.4
+forge_version=12.17.0.1922-1.9.4
 mod_version=4.1.0
 mappings_version=snapshot_nodoc_20160519

--- a/src/main/java/biomesoplenty/common/init/ModItems.java
+++ b/src/main/java/biomesoplenty/common/init/ModItems.java
@@ -122,7 +122,6 @@ import net.minecraft.init.Blocks;
 import net.minecraft.init.MobEffects;
 import net.minecraft.init.SoundEvents;
 import net.minecraft.inventory.EntityEquipmentSlot;
-import net.minecraft.item.EnumAction;
 import net.minecraft.item.Item;
 import net.minecraft.item.Item.ToolMaterial;
 import net.minecraft.item.ItemArmor.ArmorMaterial;
@@ -311,14 +310,9 @@ public class ModItems
         return item;   
     }
 
-    private static Class<?>[][] enumTypes =
+    private static ArmorMaterial addArmorMaterial(String name, String textureName, int durability, int[] reductionAmounts, int enchantability, SoundEvent soundOnEquip, float toughness)
     {
-        {ArmorMaterial.class, String.class, int.class, int[].class, int.class, SoundEvent.class, float.class}
-    };
-
-    private static ItemArmor.ArmorMaterial addArmorMaterial(String name, String textureName, int durability, int[] reductionAmounts, int enchantability, SoundEvent soundOnEquip, float toughness)
-    {
-        return EnumHelper.addEnum(enumTypes, ItemArmor.ArmorMaterial.class, name, textureName, durability, reductionAmounts, enchantability, soundOnEquip, toughness);
+        return EnumHelper.addArmorMaterial(name, textureName, durability, reductionAmounts, enchantability, soundOnEquip, toughness);
     }
     
     private static void setAxeDamageAndSpeed(ToolMaterial material, float damage, float speed)


### PR DESCRIPTION
Forge have recently made some changes to EnumHelper, which breaks the way I told you to add the armor material when EnumHelper.addArmorMaterial was broken. It's fixed now though, so I just switched back to that.