### PR TITLE
Crashfix for 'Wet' Loamy Farmland

### DIFF
--- a/src/main/java/biomesoplenty/common/blocks/BlockBOPNewFarmland.java
+++ b/src/main/java/biomesoplenty/common/blocks/BlockBOPNewFarmland.java
@@ -45,6 +45,7 @@ public class BlockBOPNewFarmland extends BlockFarmland implements ISubLocalizati
 	public String getUnlocalizedName(String baseName, ItemStack itemStack) 
 	{
 		int meta = itemStack.getItemDamage();
+		if (meta > BlockBOPNewGrass.grassTypes.length-1) meta = 0;
 		return baseName + "." + BlockBOPNewGrass.grassTypes[meta / 2];
 	}
 
@@ -72,6 +73,8 @@ public class BlockBOPNewFarmland extends BlockFarmland implements ISubLocalizati
 	@SideOnly(Side.CLIENT)
 	public IIcon getIcon(int side, int meta)
 	{
+		if (meta > BlockBOPNewGrass.grassTypes.length-1) meta = 0;
+
 		return side == 1 ? ((meta & 1) == 0 ? dry[meta / 2] : wet[meta / 2]) : dirts[meta / 2];
 	}
 


### PR DESCRIPTION
Server is Running FTB Infinity Evolved 2.5.0

About the Crash:
A player made a field of Loamy Dirt and used a Hoe on it (to get Farmland) - it was also near to water (wet).

Client Crashed with OOB.in getIcon @ BlockBOPNewFarmland.java:75

After comparing with BlockBOPNewGrass's getIcon i noticed there's no check on metadata > types length.

As i'm currently a bit short in time, i had no time to dig deeper into the code, but it seems to be valid from my perspective to just add the missing checks.


Link to crash-report:
http://pastebin.com/k2SmTdHK




