### PR TITLE
[1.10.2] Fixed piston dupe/crash

### DIFF
--- a/src/main/java/biomesoplenty/common/handler/AchievementEventHandler.java
+++ b/src/main/java/biomesoplenty/common/handler/AchievementEventHandler.java
@@ -174,24 +174,11 @@ public class AchievementEventHandler
     @SubscribeEvent
     public void onBlockPlaced(BlockEvent.PlaceEvent event)
     {
-        ItemStack stack = event.getItemInHand();
-        
-        //Blocks can be placed by things other than players
-        if (stack != null)
+        EntityPlayer player = event.getPlayer();
+        IBlockState state = event.getPlacedBlock();
+        if (player != null && state != null && state == BlockBOPSapling.paging.getVariantState(BOPTrees.SACRED_OAK))
         {
-            Item item = stack.getItem();
-            Block block = Block.getBlockFromItem(item);
-            IBlockState state = block != null && item instanceof ItemBlock ? block.getStateFromMeta(((ItemBlock)item).getMetadata(stack.getMetadata())) : null;
-
-            try
-            {
-                //Yggdrasil
-                if (state == BlockBOPSapling.paging.getVariantState(BOPTrees.SACRED_OAK))
-                {
-                    event.getPlayer().addStat(BOPAchievements.grow_sacred_oak);
-                }
-            }
-            catch(Exception e) {} //Fail quietly if there's a problem matching metadata to a block state
+            player.addStat(BOPAchievements.grow_sacred_oak);
         }
     }
     


### PR DESCRIPTION
### Initial Bug
There are two parts to the issue, a dupe and a crash. The dupe occurs when the handling for the `PlaceEvent` throws an exception, causing the stack in the player's inventory to not be decremented. Initial [stacktrace](https://paste.ee/p/IYNlj) (line 621). The crash occurs with Extra Utilities 2's Mechanical User, when set in `Use Item on Block` mode, attempting to place a piston. [log](https://paste.ee/p/l1Y3a)
This also fixes #950 
### The Fix
The issue was tracked down to [AchievementEventHandler.java#L184](https://github.com/Glitchfiend/BiomesOPlenty/blob/BOP-1.10.2-5.0.x/src/main/java/biomesoplenty/common/handler/AchievementEventHandler.java#L184) and the use of `Block#getStateFromMeta()` (which has been deprecated). Rewriting the handler to use the `IBlockState` from `BlockEvent.PlaceEvent#getPlacedBlock()` seemed to be the most optimal solution.