### PR TITLE
add amethyst to oreDict

### DIFF
--- a/src/main/java/biomesoplenty/common/init/ModCrafting.java
+++ b/src/main/java/biomesoplenty/common/init/ModCrafting.java
@@ -349,8 +349,6 @@ public class ModCrafting
         
         for (BOPGems gem : BOPGems.values())
         {
-            // TODO: for some reason, Amethyst was not included in these sections in the 1.7 code - check this is correct, deliberate behavior
-            if (gem == BOPGems.AMETHYST) {continue;}
             String gemName = CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, gem.name());
             OreDictionary.registerOre("gem"+gemName, new ItemStack(BOPItems.gem, 1, gem.ordinal()));
             OreDictionary.registerOre("ore"+gemName, new ItemStack(BOPBlocks.gem_ore , 1, gem.ordinal()));


### PR DESCRIPTION
I'm working on adding support for the Biomes o' Plenty gems in the MoreChickens mod. However, for that I would need amethyst to have an ore dictionary entry. 

I looked through old issues on the issue tracker here, the main concern seemed to be that it's an endgame item, and shouldn't be easier to get through other mods. That is why I did not modify the crafting recipes to use ore dictionary. So this will only allow other mods to use bop amethyst, but not the other way around.