### PR TITLE
Initialize fluid hardness to match vanilla fluids

### DIFF
--- a/src/main/java/biomesoplenty/common/fluids/blocks/BlockBloodFluid.java
+++ b/src/main/java/biomesoplenty/common/fluids/blocks/BlockBloodFluid.java
@@ -27,6 +27,7 @@ public class BlockBloodFluid extends BlockFluidClassic
     {
         super(fluid, Material.WATER);
         this.setLightOpacity(3);
+        this.setHardness(100.0F);
     }
 
     @Override

--- a/src/main/java/biomesoplenty/common/fluids/blocks/BlockHoneyFluid.java
+++ b/src/main/java/biomesoplenty/common/fluids/blocks/BlockHoneyFluid.java
@@ -33,6 +33,7 @@ public class BlockHoneyFluid extends BlockFluidFinite
         this.setLightOpacity(1);
         // default state should be a 'full block' of honey
         this.setDefaultState(this.blockState.getBaseState().withProperty(LEVEL, this.quantaPerBlock - 1));
+        this.setHardness(100.0F);
     }
 
     @Override

--- a/src/main/java/biomesoplenty/common/fluids/blocks/BlockHotSpringWaterFluid.java
+++ b/src/main/java/biomesoplenty/common/fluids/blocks/BlockHotSpringWaterFluid.java
@@ -37,6 +37,7 @@ public class BlockHotSpringWaterFluid extends BlockFluidClassic
     {
         super(fluid, Material.WATER);
         this.setLightOpacity(3);
+        this.setHardness(100.0F);
     }
 
     @Override

--- a/src/main/java/biomesoplenty/common/fluids/blocks/BlockPoisonFluid.java
+++ b/src/main/java/biomesoplenty/common/fluids/blocks/BlockPoisonFluid.java
@@ -32,6 +32,7 @@ public class BlockPoisonFluid extends BlockFluidClassic
         super(fluid, Material.WATER);
         this.setLightOpacity(3);
         this.quantaPerBlock = 4;
+        this.setHardness(100.0F);
     }
     
     @Override

--- a/src/main/java/biomesoplenty/common/fluids/blocks/BlockQuicksandFluid.java
+++ b/src/main/java/biomesoplenty/common/fluids/blocks/BlockQuicksandFluid.java
@@ -32,6 +32,7 @@ public class BlockQuicksandFluid extends BlockFluidClassic
         this.quantaPerBlock = 3;
         this.setLightOpacity(255);
         this.renderLayer = BlockRenderLayer.SOLID;
+        this.setHardness(0.5F);// match the hardness of vanilla sand
     }
 
     @Override


### PR DESCRIPTION
This initialises BoP fluids to have a hardness of 100.0F which matches
vanilla water and lava. Calling #setHardness subsequently sets the
blockResistance (blockHardness * 5.0F) which handles resistence to
explosions.

An exception was made for quicksand, which initializes to the same
hardness as minecraft:sand (0.5F) so that explosions won't leave piles
of quicksand floating around.

Closes #1186 