### PR TITLE
Add getModdedBiomeGrassColor and getModdedBiomeFoliageColor to biomes

### DIFF
--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenBambooForest.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenBambooForest.java
@@ -118,12 +118,12 @@ public class BiomeGenBambooForest extends BOPOverworldBiome
     @Override
     public int getGrassColorAtPos(BlockPos pos)
     {
-        return 0xBBDD54;
+        return getModdedBiomeGrassColor(0xBBDD54);
     }
     
     @Override
     public int getFoliageColorAtPos(BlockPos pos)
     {
-        return 0xBBDD54;
+        return getModdedBiomeFoliageColor(0xBBDD54);
     }
 }

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenBayou.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenBayou.java
@@ -109,12 +109,12 @@ public class BiomeGenBayou extends BOPOverworldBiome
     @Override
     public int getGrassColorAtPos(BlockPos pos)
     {
-        return 0x7DAD51;
+        return getModdedBiomeGrassColor(0x7DAD51);
     }
     
     @Override
     public int getFoliageColorAtPos(BlockPos pos)
     {
-        return 0x9DDD66;
+        return getModdedBiomeFoliageColor(0x9DDD66);
     }
 }

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenBog.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenBog.java
@@ -120,12 +120,12 @@ public class BiomeGenBog extends BOPOverworldBiome
     @Override
     public int getGrassColorAtPos(BlockPos pos)
     {
-        return 0xD69E7C;
+        return getModdedBiomeGrassColor(0xD69E7C);
     }
     
     @Override
     public int getFoliageColorAtPos(BlockPos pos)
     {
-        return 0xAAC164;
+        return getModdedBiomeFoliageColor(0xAAC164);
     }
 }

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenBorealForest.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenBorealForest.java
@@ -93,12 +93,12 @@ public class BiomeGenBorealForest extends BOPOverworldBiome
     @Override
     public int getGrassColorAtPos(BlockPos pos)
     {
-        return 0x9FB771;
+        return getModdedBiomeGrassColor(0x9FB771);
     }
     
     @Override
     public int getFoliageColorAtPos(BlockPos pos)
     {
-        return 0xC9CE65;
+        return getModdedBiomeFoliageColor(0xC9CE65);
     }
 }

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenBrushland.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenBrushland.java
@@ -79,12 +79,12 @@ public class BiomeGenBrushland extends BOPOverworldBiome
     @Override
     public int getGrassColorAtPos(BlockPos pos)
     {
-        return 0xC6C19B;
+        return getModdedBiomeGrassColor(0xC6C19B);
     }
     
     @Override
     public int getFoliageColorAtPos(BlockPos pos)
     {
-        return 0xB3BA73;
+        	return getModdedBiomeFoliageColor(0xB3BA73);
     }
 }

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenChaparral.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenChaparral.java
@@ -138,6 +138,6 @@ public class BiomeGenChaparral extends BOPOverworldBiome
     @Override
     public int getGrassColorAtPos(BlockPos pos)
     {
-        return 0xC4D675;
+        return getModdedBiomeGrassColor(0xC4D675);
     }
 }

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenCherryBlossomGrove.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenCherryBlossomGrove.java
@@ -99,12 +99,12 @@ public class BiomeGenCherryBlossomGrove extends BOPOverworldBiome
     @Override
     public int getGrassColorAtPos(BlockPos pos)
     {
-        return 0x96EA9B;
+        return getModdedBiomeGrassColor(0x96EA9B);
     }
 
     @Override
     public int getFoliageColorAtPos(BlockPos pos)
     {
-        return 0xA3FFAA;
+        return getModdedBiomeFoliageColor(0xA3FFAA);
     }
 }

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenDeadForest.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenDeadForest.java
@@ -86,12 +86,12 @@ public class BiomeGenDeadForest extends BOPOverworldBiome
     @Override
     public int getGrassColorAtPos(BlockPos pos)
     {
-        return 0xBCA165;
+        return getModdedBiomeGrassColor(0xBCA165);
     }
     
     @Override
     public int getFoliageColorAtPos(BlockPos pos)
     {
-        return 0xBCA165;
+        return getModdedBiomeFoliageColor(0xBCA165);
     }
 }

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenDeadSwamp.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenDeadSwamp.java
@@ -94,12 +94,12 @@ public class BiomeGenDeadSwamp extends BOPOverworldBiome
     @Override
     public int getGrassColorAtPos(BlockPos pos)
     {
-        return 0x66704C;
+        return getModdedBiomeGrassColor(0x66704C);
     }
     
     @Override
     public int getFoliageColorAtPos(BlockPos pos)
     {
-        return 0x66704C;
+        return getModdedBiomeFoliageColor(0x66704C);
     }
 }

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenDummyTemplate.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenDummyTemplate.java
@@ -182,12 +182,12 @@ public class BiomeGenDummyTemplate extends BOPOverworldBiome
     @Override
     public int getGrassColorAtPos(BlockPos pos)
     {
-        return 0xFFFFFF;
+        return getModdedBiomeGrassColor(0xFFFFFF);
     }
 
     @Override
     public int getFoliageColorAtPos(BlockPos pos)
     {
-        return 0xFFFFFF;
+        return getModdedBiomeFoliageColor(0xFFFFFF);
     }
 }

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenFen.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenFen.java
@@ -124,12 +124,12 @@ public class BiomeGenFen extends BOPOverworldBiome
     @Override
     public int getGrassColorAtPos(BlockPos pos)
     {
-        return 0xBAC481;
+        return getModdedBiomeGrassColor(0xBAC481);
     }
 
     @Override
     public int getFoliageColorAtPos(BlockPos pos)
     {
-        return 0xA7C166;
+        return getModdedBiomeFoliageColor(0xA7C166);
     }
 }

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenFlowerField.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenFlowerField.java
@@ -64,12 +64,12 @@ public class BiomeGenFlowerField extends BOPOverworldBiome
     @Override
     public int getGrassColorAtPos(BlockPos pos)
     {
-        return 7390273;
+        return getModdedBiomeGrassColor(7390273);
     }
 
     @Override
     public int getFoliageColorAtPos(BlockPos pos)
     {
-        return 7390273;
+        return getModdedBiomeFoliageColor(7390273);
     }
 }

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenFlowerIsland.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenFlowerIsland.java
@@ -93,12 +93,12 @@ public class BiomeGenFlowerIsland extends BOPOverworldBiome
     @Override
     public int getGrassColorAtPos(BlockPos pos)
     {
-        return 0x74D374;
+        return getModdedBiomeGrassColor(0x74D374);
     }
 
     @Override
     public int getFoliageColorAtPos(BlockPos pos)
     {
-        return 0x66E266;
+        return getModdedBiomeFoliageColor(0x66E266);
     }
 }

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenGrassland.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenGrassland.java
@@ -90,12 +90,12 @@ public class BiomeGenGrassland extends BOPOverworldBiome {
     @Override
     public int getGrassColorAtPos(BlockPos pos)
     {
-        return 0x7FDB7D;
+        return getModdedBiomeGrassColor(0x7FDB7D);
     }
     
     @Override
     public int getFoliageColorAtPos(BlockPos pos)
     {
-        return 0x7FDB7D;
+        return getModdedBiomeFoliageColor(0x7FDB7D);
     }
 }

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenGrove.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenGrove.java
@@ -84,12 +84,12 @@ public class BiomeGenGrove extends BOPOverworldBiome
     @Override
     public int getGrassColorAtPos(BlockPos pos)
     {
-        return 0x639966;
+        return getModdedBiomeGrassColor(0x639966);
     }
     
     @Override
     public int getFoliageColorAtPos(BlockPos pos)
     {
-        return 0x6CB070;
+    	return getModdedBiomeFoliageColor(0x6CB070);
     }
 }

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenLandOfLakes.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenLandOfLakes.java
@@ -104,13 +104,13 @@ public class BiomeGenLandOfLakes extends BOPOverworldBiome
     public int getGrassColorAtPos(BlockPos pos)
     {
         double noise = GRASS_COLOR_NOISE.getValue((double)pos.getX() * 0.0225D, (double)pos.getZ() * 0.0225D);
-        return noise < -0.1D ? 13414508 : 13419628;
+        return getModdedBiomeGrassColor(noise < -0.1D ? 13414508 : 13419628);
     }
 
     @Override
     public int getFoliageColorAtPos(BlockPos pos)
     {
         double noise = GRASS_COLOR_NOISE.getValue((double)pos.getX() * 0.0225D, (double)pos.getZ() * 0.0225D);
-        return noise < -0.1D ? 12766316 : 10730594;
+        return getModdedBiomeFoliageColor(noise < -0.1D ? 12766316 : 10730594);
     }  
 }

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenLavenderFields.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenLavenderFields.java
@@ -70,12 +70,12 @@ public class BiomeGenLavenderFields extends BOPOverworldBiome
     @Override
     public int getGrassColorAtPos(BlockPos pos)
     {
-        return 10601325;
+        return getModdedBiomeGrassColor(10601325);
     }
 
     @Override
     public int getFoliageColorAtPos(BlockPos pos)
     {
-        return 10601325;
+        return getModdedBiomeFoliageColor(10601325);
     }
 }

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenMeadow.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenMeadow.java
@@ -103,12 +103,12 @@ public class BiomeGenMeadow extends BOPOverworldBiome
     @Override
     public int getGrassColorAtPos(BlockPos pos)
     {
-        return 0x63B26D;
+        return getModdedBiomeGrassColor(0x63B26D);
     }
     
     @Override
     public int getFoliageColorAtPos(BlockPos pos)
     {
-        return 0x63B26D;
+        return getModdedBiomeFoliageColor(0x63B26D);
     }
 }

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenMoor.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenMoor.java
@@ -86,12 +86,12 @@ public class BiomeGenMoor extends BOPOverworldBiome
     @Override
     public int getGrassColorAtPos(BlockPos pos)
     {
-        return 0x619365;
+        return getModdedBiomeGrassColor(0x619365);
     }
     
     @Override
     public int getFoliageColorAtPos(BlockPos pos)
     {
-        return 0x619365;
+        return getModdedBiomeFoliageColor(0x619365);
     }
 }

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenMysticGrove.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenMysticGrove.java
@@ -136,12 +136,12 @@ public class BiomeGenMysticGrove extends BOPOverworldBiome
     @Override
     public int getGrassColorAtPos(BlockPos pos)
     {
-        return 0x69CFDB;
+        return getModdedBiomeGrassColor(0x69CFDB);
     }
     
     @Override
     public int getFoliageColorAtPos(BlockPos pos)
     {
-        return 0x70E099;
+        return getModdedBiomeFoliageColor(0x70E099);
     }
 }

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenOminousWoods.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenOminousWoods.java
@@ -102,12 +102,12 @@ public class BiomeGenOminousWoods extends BOPOverworldBiome
     @Override
     public int getGrassColorAtPos(BlockPos pos)
     {
-        return 0x3F4151;
+        return getModdedBiomeGrassColor(0x3F4151);
     }
     
     @Override
     public int getFoliageColorAtPos(BlockPos pos)
     {
-        return 0x3F4151;
+        return getModdedBiomeFoliageColor(0x3F4151);
     }
 }

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenOrchard.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenOrchard.java
@@ -76,12 +76,12 @@ public class BiomeGenOrchard extends BOPOverworldBiome
     @Override
     public int getGrassColorAtPos(BlockPos pos)
     {
-        return 14024557;
+        return getModdedBiomeGrassColor(14024557);
     }
 
     @Override
     public int getFoliageColorAtPos(BlockPos pos)
     {
-        return 14024557;
+        return getModdedBiomeFoliageColor(14024557);
     }
 }

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenOriginBeach.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenOriginBeach.java
@@ -83,12 +83,12 @@ public class BiomeGenOriginBeach extends BOPOverworldBiome
     @Override
     public int getGrassColorAtPos(BlockPos pos)
     {
-        return 10682207;
+        return getModdedBiomeGrassColor(10682207);
     }
 
     @Override
     public int getFoliageColorAtPos(BlockPos pos)
     {
-        return 3866368;
+        return getModdedBiomeFoliageColor(3866368);
     }
 }

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenOriginIsland.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenOriginIsland.java
@@ -108,12 +108,12 @@ public class BiomeGenOriginIsland extends BOPOverworldBiome
     @Override
     public int getGrassColorAtPos(BlockPos pos)
     {
-        return 10682207;
+        return getModdedBiomeGrassColor(10682207);
     }
 
     @Override
     public int getFoliageColorAtPos(BlockPos pos)
     {
-        return 3866368;
+        return getModdedBiomeFoliageColor(3866368);
     }
 }

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenPasture.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenPasture.java
@@ -50,12 +50,12 @@ public class BiomeGenPasture extends BOPOverworldBiome
     @Override
     public int getGrassColorAtPos(BlockPos pos)
     {
-        return 13165952;
+        return getModdedBiomeGrassColor(13165952);
     }
 
     @Override
     public int getFoliageColorAtPos(BlockPos pos)
     {
-        return 11395195;
+        return getModdedBiomeFoliageColor(11395195);
     }
 }

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenPrairie.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenPrairie.java
@@ -84,12 +84,12 @@ public class BiomeGenPrairie extends BOPOverworldBiome
     @Override
     public int getGrassColorAtPos(BlockPos pos)
     {
-        return 13165952;
+        return getModdedBiomeGrassColor(13165952);
     }
 
     @Override
     public int getFoliageColorAtPos(BlockPos pos)
     {
-        return 11395195;
+        return getModdedBiomeFoliageColor(11395195);
     }
 }

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenQuagmire.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenQuagmire.java
@@ -122,12 +122,12 @@ public class BiomeGenQuagmire extends BOPOverworldBiome
     @Override
     public int getGrassColorAtPos(BlockPos pos)
     {
-        return 0x9E8B69;
+        return getModdedBiomeGrassColor(0x9E8B69);
     }
     
     @Override
     public int getFoliageColorAtPos(BlockPos pos)
     {
-        return 0x9E8B69;
+        return getModdedBiomeFoliageColor(0x9E8B69);
     }
 }

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenRainforest.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenRainforest.java
@@ -95,12 +95,12 @@ public class BiomeGenRainforest extends BOPOverworldBiome
     @Override
     public int getGrassColorAtPos(BlockPos pos)
     {
-        return 0x1AD86C;
+        return getModdedBiomeGrassColor(0x1AD86C);
     }
     
     @Override
     public int getFoliageColorAtPos(BlockPos pos)
     {
-        return 0x14E26F;
+        return getModdedBiomeFoliageColor(0x14E26F);
     }
 }

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenSacredSprings.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenSacredSprings.java
@@ -91,12 +91,12 @@ public class BiomeGenSacredSprings extends BOPOverworldBiome
     @Override
     public int getGrassColorAtPos(BlockPos pos)
     {
-        return 39285;
+        return getModdedBiomeGrassColor(39285);
     }
     
     @Override
     public int getFoliageColorAtPos(BlockPos pos)
     {
-        return 39285;
+        return getModdedBiomeFoliageColor(39285);
     }
 }

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenSeasonalForest.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenSeasonalForest.java
@@ -93,12 +93,12 @@ public class BiomeGenSeasonalForest extends BOPOverworldBiome
     @Override
     public int getGrassColorAtPos(BlockPos pos)
     {
-        return 0xB5B952;
+    	return getModdedBiomeGrassColor(0xB5B952);
     }
     
     @Override
     public int getFoliageColorAtPos(BlockPos pos)
     {
-        return 0xA3A627;
+    	return getModdedBiomeFoliageColor(0xA3A627);
     }
 }

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenShield.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenShield.java
@@ -127,12 +127,12 @@ public class BiomeGenShield extends BOPOverworldBiome
     @Override
     public int getGrassColorAtPos(BlockPos pos)
     {
-        return 0x7C9B45;
+        return getModdedBiomeGrassColor(0x7C9B45);
     }
     
     @Override
     public int getFoliageColorAtPos(BlockPos pos)
     {
-        return 0x8EAF4F;
+        return getModdedBiomeFoliageColor(0x8EAF4F);
     }
 }

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenSnowyForest.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenSnowyForest.java
@@ -78,12 +78,12 @@ public class BiomeGenSnowyForest extends BOPOverworldBiome
     @Override
     public int getGrassColorAtPos(BlockPos pos)
     {
-        return 0xBCA165;
+        return getModdedBiomeGrassColor(0xBCA165);
     }
 
     @Override
     public int getFoliageColorAtPos(BlockPos pos)
     {
-        return 0xBCA165;
+        return getModdedBiomeFoliageColor(0xBCA165);
     }
 }

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenSteppe.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenSteppe.java
@@ -108,13 +108,13 @@ public class BiomeGenSteppe extends BOPOverworldBiome
     public int getGrassColorAtPos(BlockPos pos)
     {
         double noise = GRASS_COLOR_NOISE.getValue((double)pos.getX() * 0.0225D, (double)pos.getZ() * 0.0225D);
-        return noise < -0.1D ? 13741418 : 13018487;
+        return getModdedBiomeGrassColor(noise < -0.1D ? 13741418 : 13018487);
     }
 
     @Override
     public int getFoliageColorAtPos(BlockPos pos)
     {
         double noise = GRASS_COLOR_NOISE.getValue((double)pos.getX() * 0.0225D, (double)pos.getZ() * 0.0225D);
-        return noise < -0.1D ? 13741418 : 13018487;
+        return getModdedBiomeFoliageColor(noise < -0.1D ? 13741418 : 13018487);
     }
 }

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenTemperateRainforest.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenTemperateRainforest.java
@@ -112,12 +112,12 @@ public class BiomeGenTemperateRainforest extends BOPOverworldBiome
     @Override
     public int getGrassColorAtPos(BlockPos pos)
     {
-        return 0xB6D367;
+        return getModdedBiomeGrassColor(0xB6D367);
     }
     
     @Override
     public int getFoliageColorAtPos(BlockPos pos)
     {
-        return 0xBBDD63;
+        return getModdedBiomeFoliageColor(0xBBDD63);
     }
 }

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenTropicalRainforest.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenTropicalRainforest.java
@@ -103,12 +103,12 @@ public class BiomeGenTropicalRainforest extends BOPOverworldBiome
     @Override
     public int getGrassColorAtPos(BlockPos pos)
     {
-        return 0xA7E140;
+        return getModdedBiomeGrassColor(0xA7E140);
     }
     
     @Override
     public int getFoliageColorAtPos(BlockPos pos)
     {
-        return 0x88E140;
+        return getModdedBiomeFoliageColor(0x88E140);
     }
 }

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenTundra.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenTundra.java
@@ -92,13 +92,13 @@ public class BiomeGenTundra extends BOPOverworldBiome
     @Override
     public int getGrassColorAtPos(BlockPos pos)
     {
-        return 0xAD8456;
+        return getModdedBiomeGrassColor(0xAD8456);
     }
     
     @Override
     public int getFoliageColorAtPos(BlockPos pos)
     {
-        return 0xBF664E;
+        return getModdedBiomeFoliageColor(0xBF664E);
     }
 
 }

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenWasteland.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenWasteland.java
@@ -86,12 +86,12 @@ public class BiomeGenWasteland extends BOPOverworldBiome
     @Override
     public int getGrassColorAtPos(BlockPos pos)
     {
-        return 0x9DA078;
+        return getModdedBiomeGrassColor(0x9DA078);
     }
     
     @Override
     public int getFoliageColorAtPos(BlockPos pos)
     {
-        return 0x999E55;
+        return getModdedBiomeFoliageColor(0x999E55);
     }
 }

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenWetland.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenWetland.java
@@ -121,12 +121,12 @@ public class BiomeGenWetland extends BOPOverworldBiome
     @Override
     public int getGrassColorAtPos(BlockPos pos)
     {
-        return 0x5A935F;
+        return getModdedBiomeGrassColor(0x5A935F);
     }
     
     @Override
     public int getFoliageColorAtPos(BlockPos pos)
     {
-        return 0x4F9657;
+        return getModdedBiomeFoliageColor(0x4F9657);
     }
 }

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenWoodland.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenWoodland.java
@@ -98,12 +98,12 @@ public class BiomeGenWoodland extends BOPOverworldBiome
     @Override
     public int getGrassColorAtPos(BlockPos pos)
     {
-        return 0x8DC047;
+        return getModdedBiomeGrassColor(0x8DC047);
     }
 
     @Override
     public int getFoliageColorAtPos(BlockPos pos)
     {
-        return 0x72AF1A;
+        return getModdedBiomeFoliageColor(0x72AF1A);
     }
 }

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenXericShrubland.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenXericShrubland.java
@@ -98,12 +98,12 @@ public class BiomeGenXericShrubland extends BOPOverworldBiome
     @Override
     public int getGrassColorAtPos(BlockPos pos)
     {
-        return 0xD4E0A6;
+        return getModdedBiomeGrassColor(0xD4E0A6);
     }
     
     @Override
     public int getFoliageColorAtPos(BlockPos pos)
     {
-        return 0xD4E0A6;
+        return getModdedBiomeFoliageColor(0xD4E0A6);
     }
 }


### PR DESCRIPTION
This adds getModdedBiomeGrassColor and getModdedBiomeFoliageColor to biomes.  These calls are part of the standard way biome color operates.  If these are not represented then players that use mods that make color changes may not get what they are expecting.