### PR TITLE
Fix for mods which replace certain vanilla blocks in the registry

### DIFF
--- a/src/main/java/biomesoplenty/core/BiomesOPlenty.java
+++ b/src/main/java/biomesoplenty/core/BiomesOPlenty.java
@@ -85,8 +85,6 @@ public class BiomesOPlenty
         ModPotions.init();
         ModBlockQueries.init();
         
-        ModGenerators.init();
-        ModBiomes.init();
         ModVanillaCompat.init();
         ModHandlers.init();
         
@@ -104,6 +102,8 @@ public class BiomesOPlenty
     @EventHandler
     public void postInit(FMLPostInitializationEvent event)
     {
+        ModGenerators.init();
+        ModBiomes.init();
         ModCompatibility.postInit();
     }
 


### PR DESCRIPTION
This PR moves the Generator and Biomes init to the post init section of the Forge booting schedule to ensure proper support with mods replacing entries in MCs registry.