### PR TITLE
Use Minecraft#world when spawning particles on the client, fixes #1368

### DIFF
--- a/src/main/java/biomesoplenty/common/block/BlockBOPBlueFire.java
+++ b/src/main/java/biomesoplenty/common/block/BlockBOPBlueFire.java
@@ -91,7 +91,7 @@ public class BlockBOPBlueFire extends Block implements IBOPBlock
             	double d0 = (double)pos.getX() + world.rand.nextDouble();
 	            double d1 = (double)pos.getY() + world.rand.nextDouble() * 0.5D + 0.5D;
 	            double d2 = (double)pos.getZ() + world.rand.nextDouble();
-	            BiomesOPlenty.proxy.spawnParticle(BOPParticleTypes.CURSE, world, d0, d1, d2, 0.0D, 0.0D, 0.0D, new int[0]);
+	            BiomesOPlenty.proxy.spawnParticle(BOPParticleTypes.CURSE, d0, d1, d2, 0.0D, 0.0D, 0.0D, new int[0]);
             }
         }
     }
@@ -185,7 +185,7 @@ public class BlockBOPBlueFire extends Block implements IBOPBlock
             double d0 = (double)pos.getX() + rand.nextDouble();
             double d1 = (double)pos.getY() + rand.nextDouble() * 0.5D + 0.5D;
             double d2 = (double)pos.getZ() + rand.nextDouble();
-            BiomesOPlenty.proxy.spawnParticle(BOPParticleTypes.CURSE, worldIn, d0, d1, d2, 0.0D, 0.0D, 0.0D, new int[0]);
+            BiomesOPlenty.proxy.spawnParticle(BOPParticleTypes.CURSE, d0, d1, d2, 0.0D, 0.0D, 0.0D, new int[0]);
         }
 	}
 

--- a/src/main/java/biomesoplenty/common/entities/projectiles/EntityMudball.java
+++ b/src/main/java/biomesoplenty/common/entities/projectiles/EntityMudball.java
@@ -3,12 +3,8 @@ package biomesoplenty.common.entities.projectiles;
 import biomesoplenty.api.particle.BOPParticleTypes;
 import biomesoplenty.core.BiomesOPlenty;
 import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.IProjectile;
 import net.minecraft.entity.projectile.EntityThrowable;
-import net.minecraft.init.MobEffects;
-import net.minecraft.potion.PotionEffect;
 import net.minecraft.util.DamageSource;
-import net.minecraft.util.EnumParticleTypes;
 import net.minecraft.util.datafix.DataFixer;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.World;
@@ -46,7 +42,7 @@ public class EntityMudball extends EntityThrowable
         {
             for (int i = 0; i < 8; ++i)
             {
-                BiomesOPlenty.proxy.spawnParticle(BOPParticleTypes.MUD, this.world, this.posX, this.posY, this.posZ);
+                BiomesOPlenty.proxy.spawnParticle(BOPParticleTypes.MUD, this.posX, this.posY, this.posZ);
             }
         }
     }

--- a/src/main/java/biomesoplenty/common/handler/TrailsEventHandler.java
+++ b/src/main/java/biomesoplenty/common/handler/TrailsEventHandler.java
@@ -62,7 +62,7 @@ public class TrailsEventHandler
 			        if (player.posX != player.prevPosX || player.posZ != player.prevPosZ) //Particles should only spawn if the player is moving
 			        {
 			            //Move the particle up by 0.01 on spawn to prevent z-fighting (the trail particles move down with time)
-			            BiomesOPlenty.proxy.spawnParticle(BOPParticleTypes.PLAYER_TRAIL, world, player.posX + offsetX, ((int)player.posY) + groundYOffset + 0.01, player.posZ + offsetZ, trailName);	
+			            BiomesOPlenty.proxy.spawnParticle(BOPParticleTypes.PLAYER_TRAIL, player.posX + offsetX, ((int)player.posY) + groundYOffset + 0.01, player.posZ + offsetZ, trailName);
 			        }
 			    }
 			}

--- a/src/main/java/biomesoplenty/core/ClientProxy.java
+++ b/src/main/java/biomesoplenty/core/ClientProxy.java
@@ -170,24 +170,31 @@ public class ClientProxy extends CommonProxy
     }
     
     @Override
-    public void spawnParticle(BOPParticleTypes type, World parWorld, double x, double y, double z, Object... info)
+    public void spawnParticle(BOPParticleTypes type, double x, double y, double z, Object... info)
     {
         Minecraft minecraft = Minecraft.getMinecraft();
+        World world = minecraft.world;
+
+        if (world == null)
+        {
+            return;
+        }
+
         Particle entityFx = null;
         switch (type)
         {
         case MUD:
             int itemId = Item.getIdFromItem(BOPItems.mudball);
-            minecraft.world.spawnParticle(EnumParticleTypes.ITEM_CRACK, x, y, z, MathHelper.nextDouble(parWorld.rand, -0.08D, 0.08D), MathHelper.nextDouble(parWorld.rand, -0.08D, 0.08D), MathHelper.nextDouble(parWorld.rand, -0.08D, 0.08D), itemId);
+            minecraft.world.spawnParticle(EnumParticleTypes.ITEM_CRACK, x, y, z, MathHelper.nextDouble(world.rand, -0.08D, 0.08D), MathHelper.nextDouble(world.rand, -0.08D, 0.08D), MathHelper.nextDouble(world.rand, -0.08D, 0.08D), itemId);
             return;
         case PLAYER_TRAIL:
             if (info.length < 1)
                 throw new RuntimeException("Missing argument for trail name!");
 
-            entityFx = new EntityTrailFX(parWorld, x, y, z, (String)info[0]);
+            entityFx = new EntityTrailFX(world, x, y, z, (String)info[0]);
             break;
         case CURSE:
-            entityFx = new EntityCurseFX(parWorld, x, y, z, MathHelper.nextDouble(parWorld.rand, -0.03, 0.03), 0.05D, MathHelper.nextDouble(parWorld.rand, -0.03, 0.03));
+            entityFx = new EntityCurseFX(world, x, y, z, MathHelper.nextDouble(world.rand, -0.03, 0.03), 0.05D, MathHelper.nextDouble(world.rand, -0.03, 0.03));
             break;
         default:
             break;

--- a/src/main/java/biomesoplenty/core/CommonProxy.java
+++ b/src/main/java/biomesoplenty/core/CommonProxy.java
@@ -11,7 +11,6 @@ package biomesoplenty.core;
 import biomesoplenty.api.particle.BOPParticleTypes;
 import net.minecraft.block.Block;
 import net.minecraft.item.Item;
-import net.minecraft.world.World;
 
 public class CommonProxy
 {
@@ -21,5 +20,5 @@ public class CommonProxy
     public void registerBlockSided(Block block) {}
     public void registerItemSided(Item item) {}
     public void registerFluidBlockRendering(Block block, String name) {}
-    public void spawnParticle(BOPParticleTypes type, World parWorld, double x, double y, double z, Object... info) {}
+    public void spawnParticle(BOPParticleTypes type, double x, double y, double z, Object... info) {}
 }


### PR DESCRIPTION
This patch removes the World argument from the proxy method to spawn particles as it is not needed and will prevent consumers from using the server's world. We instead grab the World instance from `Minecraft#world` and return early if it's null (which is probably done in paranoia.)