### PR TITLE
Fix #760 without changing the default locale to en_us

### DIFF
--- a/src/main/java/biomesoplenty/api/enums/BOPFlowers.java
+++ b/src/main/java/biomesoplenty/api/enums/BOPFlowers.java
@@ -10,13 +10,15 @@ package biomesoplenty.api.enums;
 
 import net.minecraft.util.IStringSerializable;
 
+import java.util.Locale;
+
 public enum BOPFlowers implements IStringSerializable, IPagedVariants
 {
     CLOVER, SWAMPFLOWER, DEATHBLOOM, GLOWFLOWER, BLUE_HYDRANGEA, ORANGE_COSMOS, PINK_DAFFODIL, WILDFLOWER, VIOLET, WHITE_ANEMONE, ENDERLOTUS, BROMELIAD, WILTED_LILY, PINK_HIBISCUS, LILY_OF_THE_VALLEY, BURNING_BLOSSOM, LAVENDER, GOLDENROD, BLUEBELLS, MINERS_DELIGHT, ICY_IRIS, ROSE;
     
     @Override
     public String getName() {
-        return this.name().toLowerCase();
+        return this.name().toLowerCase(Locale.ENGLISH);
     }
     @Override
     public String toString()

--- a/src/main/java/biomesoplenty/api/enums/BOPGems.java
+++ b/src/main/java/biomesoplenty/api/enums/BOPGems.java
@@ -10,13 +10,15 @@ package biomesoplenty.api.enums;
 
 import net.minecraft.util.IStringSerializable;
 
+import java.util.Locale;
+
 public enum BOPGems implements IStringSerializable
 {
     AMETHYST, RUBY, PERIDOT, TOPAZ, TANZANITE, MALACHITE, SAPPHIRE, AMBER;
     @Override
     public String getName()
     {
-        return this.name().toLowerCase();
+        return this.name().toLowerCase(Locale.ENGLISH);
     }
     @Override
     public String toString()

--- a/src/main/java/biomesoplenty/api/enums/BOPPlants.java
+++ b/src/main/java/biomesoplenty/api/enums/BOPPlants.java
@@ -10,6 +10,8 @@ package biomesoplenty.api.enums;
 
 import net.minecraft.util.IStringSerializable;
 
+import java.util.Locale;
+
 public enum BOPPlants implements IStringSerializable, IPagedVariants
 {
     
@@ -17,7 +19,7 @@ public enum BOPPlants implements IStringSerializable, IPagedVariants
     
     @Override
     public String getName() {
-        return this.name().toLowerCase();
+        return this.name().toLowerCase(Locale.ENGLISH);
     }
     @Override
     public String toString()

--- a/src/main/java/biomesoplenty/api/enums/BOPTrees.java
+++ b/src/main/java/biomesoplenty/api/enums/BOPTrees.java
@@ -12,6 +12,8 @@ import com.google.common.base.Predicate;
 
 import net.minecraft.util.IStringSerializable;
 
+import java.util.Locale;
+
 public enum BOPTrees implements IStringSerializable, IPagedVariants
 {
     
@@ -19,7 +21,7 @@ public enum BOPTrees implements IStringSerializable, IPagedVariants
     
     @Override
     public String getName() {
-        return this.name().toLowerCase();
+        return this.name().toLowerCase(Locale.ENGLISH);
     }
     @Override
     public String toString()

--- a/src/main/java/biomesoplenty/api/enums/BOPWoods.java
+++ b/src/main/java/biomesoplenty/api/enums/BOPWoods.java
@@ -12,6 +12,8 @@ import com.google.common.base.Predicate;
 
 import net.minecraft.util.IStringSerializable;
 
+import java.util.Locale;
+
 public enum BOPWoods implements IStringSerializable, IPagedVariants
 {
     
@@ -19,7 +21,7 @@ public enum BOPWoods implements IStringSerializable, IPagedVariants
     
     @Override
     public String getName() {
-        return this.name().toLowerCase();
+        return this.name().toLowerCase(Locale.ENGLISH);
     }
     @Override
     public String toString()

--- a/src/main/java/biomesoplenty/client/gui/GuiBOPFactory.java
+++ b/src/main/java/biomesoplenty/client/gui/GuiBOPFactory.java
@@ -35,10 +35,10 @@ public class GuiBOPFactory extends DefaultGuiFactory
     {
         List<IConfigElement> list = new ArrayList<IConfigElement>();
 
-        List<IConfigElement> convenience_settings = new ConfigElement(GameplayConfigurationHandler.config.getCategory(CONVENIENCE_SETTINGS.toLowerCase())).getChildElements();
-        List<IConfigElement> gui_settings = new ConfigElement(config.getCategory(GUI_SETTINGS.toLowerCase())).getChildElements();
-        List<IConfigElement> texture_settings = new ConfigElement(config.getCategory(VISUAL_SETTINGS.toLowerCase())).getChildElements();
-        List<IConfigElement> trail_settings = new ConfigElement(config.getCategory(TRAIL_SETTINGS.toLowerCase())).getChildElements();
+        List<IConfigElement> convenience_settings = new ConfigElement(GameplayConfigurationHandler.config.getCategory(CONVENIENCE_SETTINGS)).getChildElements();
+        List<IConfigElement> gui_settings = new ConfigElement(config.getCategory(GUI_SETTINGS)).getChildElements();
+        List<IConfigElement> texture_settings = new ConfigElement(config.getCategory(VISUAL_SETTINGS)).getChildElements();
+        List<IConfigElement> trail_settings = new ConfigElement(config.getCategory(TRAIL_SETTINGS)).getChildElements();
 
         list.add(new DummyCategoryElement(I18n.translateToLocal("config.category.convenienceSettings.title"), "config.category.convenienceSettings", convenience_settings));
         list.add(new DummyCategoryElement(I18n.translateToLocal("config.category.guiSettings.title"), "config.category.guiSettings", gui_settings));

--- a/src/main/java/biomesoplenty/common/biome/BOPBiome.java
+++ b/src/main/java/biomesoplenty/common/biome/BOPBiome.java
@@ -106,7 +106,7 @@ public abstract class BOPBiome extends Biome implements IExtendedBiome
         IConfigObj confWeights = conf.getObject("weights");
         for (BOPClimates climate : BOPClimates.values())
         {
-            Integer weight = confWeights.getInt(climate.name().toLowerCase(), this.weightMap.get(climate));
+            Integer weight = confWeights.getInt(climate.name().toLowerCase(Locale.ENGLISH), this.weightMap.get(climate));
             if (weight == null) {continue;}
             if (weight.intValue() < 1)
             {

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenAlps.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenAlps.java
@@ -27,6 +27,8 @@ import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.passive.EntityLlama;
 import net.minecraft.init.Blocks;
 
+import java.util.Locale;
+
 public class BiomeGenAlps extends BOPOverworldBiome
 {
     public enum AlpsType {ALPS, ALPS_FOOTHILLS}
@@ -35,7 +37,7 @@ public class BiomeGenAlps extends BOPOverworldBiome
     
     public BiomeGenAlps(AlpsType type)
     {
-        super(type.name().toLowerCase(), new PropsBuilder(CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, type.toString())).withGuiColour(13421772).withSnowEnabled().withTemperature(-0.25F).withRainfall(0.3F));
+        super(type.name().toLowerCase(Locale.ENGLISH), new PropsBuilder(CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, type.toString())).withGuiColour(13421772).withSnowEnabled().withTemperature(-0.25F).withRainfall(0.3F));
         
         this.type = type;
         

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenMountain.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenMountain.java
@@ -37,6 +37,8 @@ import net.minecraft.entity.passive.EntityWolf;
 import net.minecraft.init.Blocks;
 import net.minecraft.world.biome.Biome;
 
+import java.util.Locale;
+
 public class BiomeGenMountain extends BOPOverworldBiome
 {
     
@@ -50,7 +52,7 @@ public class BiomeGenMountain extends BOPOverworldBiome
         
     public BiomeGenMountain(MountainType type)
     {
-        super(type.name().toLowerCase(), new PropsBuilder(CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, type.toString())).withGuiColour(0x80A355).withTemperature(0.5F).withRainfall(0.1F));
+        super(type.name().toLowerCase(Locale.ENGLISH), new PropsBuilder(CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, type.toString())).withGuiColour(0x80A355).withTemperature(0.5F).withRainfall(0.1F));
         
         this.type = type;
         

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenRedwoodForest.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenRedwoodForest.java
@@ -1,5 +1,6 @@
 package biomesoplenty.common.biome.overworld;
 
+import java.util.Locale;
 import java.util.Random;
 
 import com.google.common.base.CaseFormat;
@@ -38,7 +39,7 @@ public class BiomeGenRedwoodForest extends BOPOverworldBiome
 	
     public BiomeGenRedwoodForest(ForestType type)
     {
-        super(type.name().toLowerCase(), new PropsBuilder(CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, type.toString())).withGuiColour(0x6DAA3C).withTemperature(0.7F).withRainfall(0.7F));
+        super(type.name().toLowerCase(Locale.ENGLISH), new PropsBuilder(CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, type.toString())).withGuiColour(0x6DAA3C).withTemperature(0.7F).withRainfall(0.7F));
 
         this.type = type;
         

--- a/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenTundra.java
+++ b/src/main/java/biomesoplenty/common/biome/overworld/BiomeGenTundra.java
@@ -40,6 +40,8 @@ import net.minecraft.init.Blocks;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.biome.Biome;
 
+import java.util.Locale;
+
 public class BiomeGenTundra extends BOPOverworldBiome
 {    
 	public enum TundraType {TUNDRA, SNOWY_TUNDRA}
@@ -48,7 +50,7 @@ public class BiomeGenTundra extends BOPOverworldBiome
 	
     public BiomeGenTundra(TundraType type)
     {
-        super(type.name().toLowerCase(), new PropsBuilder(CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, type.toString())).withGuiColour(0xA09456).withTemperature((type == TundraType.TUNDRA) ? 0.2F : 0.0F).withRainfall(0.5F));
+        super(type.name().toLowerCase(Locale.ENGLISH), new PropsBuilder(CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, type.toString())).withGuiColour(0xA09456).withTemperature((type == TundraType.TUNDRA) ? 0.2F : 0.0F).withRainfall(0.5F));
 
         this.type = type;
         

--- a/src/main/java/biomesoplenty/common/block/BlockBOPCoral.java
+++ b/src/main/java/biomesoplenty/common/block/BlockBOPCoral.java
@@ -21,6 +21,8 @@ import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
+import java.util.Locale;
+
 public class BlockBOPCoral extends BlockBOPDecoration
 {
     
@@ -30,7 +32,7 @@ public class BlockBOPCoral extends BlockBOPDecoration
         @Override
         public String getName()
         {
-            return this.name().toLowerCase();
+            return this.name().toLowerCase(Locale.ENGLISH);
         }
         @Override
         public String toString()

--- a/src/main/java/biomesoplenty/common/block/BlockBOPDirt.java
+++ b/src/main/java/biomesoplenty/common/block/BlockBOPDirt.java
@@ -8,6 +8,7 @@
 
 package biomesoplenty.common.block;
 
+import java.util.Locale;
 import java.util.Random;
 
 import biomesoplenty.api.block.BOPBlocks;
@@ -43,7 +44,7 @@ public class BlockBOPDirt extends Block implements IBOPBlock, ISustainsPlantType
         @Override
         public String getName()
         {
-            return this.name().toLowerCase();
+            return this.name().toLowerCase(Locale.ENGLISH);
         }
         @Override
         public String toString()

--- a/src/main/java/biomesoplenty/common/block/BlockBOPDoubleDecoration.java
+++ b/src/main/java/biomesoplenty/common/block/BlockBOPDoubleDecoration.java
@@ -9,6 +9,7 @@
 package biomesoplenty.common.block;
 
 import java.util.List;
+import java.util.Locale;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
@@ -34,7 +35,7 @@ public class BlockBOPDoubleDecoration extends BlockBOPDecoration {
         @Override
         public String getName()
         {
-            return this.name().toLowerCase();
+            return this.name().toLowerCase(Locale.ENGLISH);
         }
         @Override
         public String toString()

--- a/src/main/java/biomesoplenty/common/block/BlockBOPDoublePlant.java
+++ b/src/main/java/biomesoplenty/common/block/BlockBOPDoublePlant.java
@@ -9,6 +9,7 @@
 package biomesoplenty.common.block;
 
 import java.util.List;
+import java.util.Locale;
 
 import com.google.common.collect.ImmutableSet;
 
@@ -48,7 +49,7 @@ public class BlockBOPDoublePlant extends BlockBOPDoubleDecoration implements ISh
         @Override
         public String getName()
         {
-            return this.name().toLowerCase();
+            return this.name().toLowerCase(Locale.ENGLISH);
         }
         @Override
         public String toString()

--- a/src/main/java/biomesoplenty/common/block/BlockBOPGrass.java
+++ b/src/main/java/biomesoplenty/common/block/BlockBOPGrass.java
@@ -8,6 +8,7 @@
 
 package biomesoplenty.common.block;
 
+import java.util.Locale;
 import java.util.Random;
 
 import javax.annotation.Nullable;
@@ -55,7 +56,7 @@ public class BlockBOPGrass extends BlockGrass implements IBOPBlock, ISustainsPla
         @Override
         public String getName()
         {
-            return this.name().toLowerCase();
+            return this.name().toLowerCase(Locale.ENGLISH);
         }
         @Override
         public String toString()

--- a/src/main/java/biomesoplenty/common/block/BlockBOPHalfOtherSlab.java
+++ b/src/main/java/biomesoplenty/common/block/BlockBOPHalfOtherSlab.java
@@ -9,6 +9,7 @@
 package biomesoplenty.common.block;
 
 import java.util.List;
+import java.util.Locale;
 
 import com.google.common.collect.ImmutableSet;
 
@@ -48,7 +49,7 @@ public class BlockBOPHalfOtherSlab extends BlockSlab implements IBOPBlock
         @Override
         public String getName()
         {
-            return this.name().toLowerCase();
+            return this.name().toLowerCase(Locale.ENGLISH);
         }
         @Override
         public String toString()

--- a/src/main/java/biomesoplenty/common/block/BlockBOPHive.java
+++ b/src/main/java/biomesoplenty/common/block/BlockBOPHive.java
@@ -8,6 +8,7 @@
 
 package biomesoplenty.common.block;
 
+import java.util.Locale;
 import java.util.Random;
 
 import biomesoplenty.api.item.BOPItems;
@@ -45,7 +46,7 @@ public class BlockBOPHive extends Block implements IBOPBlock
         @Override
         public String getName()
         {
-            return this.name().toLowerCase();
+            return this.name().toLowerCase(Locale.ENGLISH);
         }
         @Override
         public String toString()

--- a/src/main/java/biomesoplenty/common/block/BlockBOPLilypad.java
+++ b/src/main/java/biomesoplenty/common/block/BlockBOPLilypad.java
@@ -28,6 +28,8 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
+import java.util.Locale;
+
 public class BlockBOPLilypad extends BlockLilyPad implements IBOPBlock
 {
     
@@ -38,7 +40,7 @@ public class BlockBOPLilypad extends BlockLilyPad implements IBOPBlock
         @Override
         public String getName()
         {
-            return this.name().toLowerCase();
+            return this.name().toLowerCase(Locale.ENGLISH);
         }
         @Override
         public String toString()

--- a/src/main/java/biomesoplenty/common/block/BlockBOPMud.java
+++ b/src/main/java/biomesoplenty/common/block/BlockBOPMud.java
@@ -9,6 +9,7 @@
 package biomesoplenty.common.block;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Random;
 
 import javax.annotation.Nullable;
@@ -52,7 +53,7 @@ public class BlockBOPMud extends Block implements IBOPBlock, ISustainsPlantType
         @Override
         public String getName()
         {
-            return this.name().toLowerCase();
+            return this.name().toLowerCase(Locale.ENGLISH);
         }
         @Override
         public String toString()

--- a/src/main/java/biomesoplenty/common/block/BlockBOPMushroom.java
+++ b/src/main/java/biomesoplenty/common/block/BlockBOPMushroom.java
@@ -25,6 +25,8 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
+import java.util.Locale;
+
 // TODO: mushroom spreading? giant mushrooms with bonemeal? mushrooms popping if too bright?
 public class BlockBOPMushroom extends BlockBOPDecoration
 {
@@ -35,7 +37,7 @@ public class BlockBOPMushroom extends BlockBOPDecoration
         @Override
         public String getName()
         {
-            return this.name().toLowerCase();
+            return this.name().toLowerCase(Locale.ENGLISH);
         }
         @Override
         public String toString()

--- a/src/main/java/biomesoplenty/common/block/BlockBOPSeaweed.java
+++ b/src/main/java/biomesoplenty/common/block/BlockBOPSeaweed.java
@@ -25,6 +25,8 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
+import java.util.Locale;
+
 public class BlockBOPSeaweed extends BlockBOPDecoration implements IBOPBlock
 {
     
@@ -36,7 +38,7 @@ public class BlockBOPSeaweed extends BlockBOPDecoration implements IBOPBlock
         @Override
         public String getName()
         {
-            return this.name().toLowerCase();
+            return this.name().toLowerCase(Locale.ENGLISH);
         }
         @Override
         public String toString()
@@ -51,7 +53,7 @@ public class BlockBOPSeaweed extends BlockBOPDecoration implements IBOPBlock
         @Override
         public String getName()
         {
-            return this.name().toLowerCase();
+            return this.name().toLowerCase(Locale.ENGLISH);
         }
         @Override
         public String toString()

--- a/src/main/java/biomesoplenty/common/block/BlockBOPTerrarium.java
+++ b/src/main/java/biomesoplenty/common/block/BlockBOPTerrarium.java
@@ -28,6 +28,8 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
+import java.util.Locale;
+
 public class BlockBOPTerrarium extends Block implements IBOPBlock
 {
 	protected static final AxisAlignedBB BOUNDING_BOX = new AxisAlignedBB(0.25D, 0.0D, 0.25D, 0.75D, 0.75D, 0.75D);
@@ -39,7 +41,7 @@ public class BlockBOPTerrarium extends Block implements IBOPBlock
         @Override
         public String getName()
         {
-            return this.name().toLowerCase();
+            return this.name().toLowerCase(Locale.ENGLISH);
         }
         @Override
         public String toString()

--- a/src/main/java/biomesoplenty/common/block/BlockBOPWhiteSandstone.java
+++ b/src/main/java/biomesoplenty/common/block/BlockBOPWhiteSandstone.java
@@ -8,6 +8,7 @@
 
 package biomesoplenty.common.block;
 
+import java.util.Locale;
 import java.util.Random;
 
 import biomesoplenty.api.item.BOPItems;
@@ -45,7 +46,7 @@ public class BlockBOPWhiteSandstone extends Block implements IBOPBlock
         @Override
         public String getName()
         {
-            return this.name().toLowerCase();
+            return this.name().toLowerCase(Locale.ENGLISH);
         }
         @Override
         public String toString()

--- a/src/main/java/biomesoplenty/common/item/ItemJarFilled.java
+++ b/src/main/java/biomesoplenty/common/item/ItemJarFilled.java
@@ -22,6 +22,7 @@ import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
+import java.util.Locale;
 import java.util.Objects;
 
 public class ItemJarFilled extends Item
@@ -34,7 +35,7 @@ public class ItemJarFilled extends Item
         @Override
         public String getName()
         {
-            return this.name().toLowerCase();
+            return this.name().toLowerCase(Locale.ENGLISH);
         }
         @Override
         public String toString()

--- a/src/main/java/biomesoplenty/common/world/BOPWorldSettings.java
+++ b/src/main/java/biomesoplenty/common/world/BOPWorldSettings.java
@@ -9,6 +9,7 @@
 package biomesoplenty.common.world;
 
 import java.io.File;
+import java.util.Locale;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -126,10 +127,10 @@ public class BOPWorldSettings implements IBOPWorldSettings
     public String toJson()
     {
         JsonObject obj = new JsonObject();
-        obj.addProperty("landScheme", this.landScheme.name().toLowerCase());
-        obj.addProperty("tempScheme", this.tempScheme.name().toLowerCase());
-        obj.addProperty("rainScheme", this.rainScheme.name().toLowerCase());
-        obj.addProperty("biomeSize", this.biomeSize.name().toLowerCase());
+        obj.addProperty("landScheme", this.landScheme.name().toLowerCase(Locale.ENGLISH));
+        obj.addProperty("tempScheme", this.tempScheme.name().toLowerCase(Locale.ENGLISH));
+        obj.addProperty("rainScheme", this.rainScheme.name().toLowerCase(Locale.ENGLISH));
+        obj.addProperty("biomeSize", this.biomeSize.name().toLowerCase(Locale.ENGLISH));
         obj.addProperty("amplitude", this.amplitude);
         obj.addProperty("generateBopOre", this.generateBopGems);
         obj.addProperty("generatePoisonIvy", this.generatePoisonIvy);

--- a/src/main/java/biomesoplenty/core/BiomesOPlenty.java
+++ b/src/main/java/biomesoplenty/core/BiomesOPlenty.java
@@ -9,7 +9,6 @@
 package biomesoplenty.core;
 
 import java.io.File;
-import java.util.Locale;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -70,9 +69,6 @@ public class BiomesOPlenty
     public void preInit(FMLPreInitializationEvent event)
     {
         configDirectory = new File(event.getModConfigurationDirectory(), "biomesoplenty");
-
-        //fixes turkish locale bug
-        Locale.setDefault(Locale.ENGLISH);
 
         TrailManager.retrieveTrails();
         ModConfiguration.init(configDirectory);

--- a/src/main/java/biomesoplenty/core/ClientProxy.java
+++ b/src/main/java/biomesoplenty/core/ClientProxy.java
@@ -156,7 +156,7 @@ public class ClientProxy extends CommonProxy
     @Override
     public void registerFluidBlockRendering(Block block, String name) 
     {
-        final ModelResourceLocation fluidLocation = new ModelResourceLocation(BiomesOPlenty.MOD_ID.toLowerCase() + ":fluids", name);
+        final ModelResourceLocation fluidLocation = new ModelResourceLocation(BiomesOPlenty.MOD_ID + ":fluids", name);
 
         // use a custom state mapper which will ignore the LEVEL property
         ModelLoader.setCustomStateMapper(block, new StateMapperBase()


### PR DESCRIPTION
14ce249 changes the default locale, which affects many server mods or plugins. Server mods and plugins are not able to change the behavior of clients so the i18n works can only be done on server side, and many of them identify which language to use by `Locale.getDefault()`.

The default locale can be passed in via command args such as `-Duser.country=XX -Duser.language=xx` while it is hardcoded to `Locale.ENGLISH` in the latest release of BOP.

Maybe it is also necessary to cherry-pick these commits into 1.13+ branches in my opinion.