### PR TITLE
Prevent modification of ItemStack.EMPTY's NBT

### DIFF
--- a/src/main/java/biomesoplenty/common/crafting/BiomeEssenceRecipe.java
+++ b/src/main/java/biomesoplenty/common/crafting/BiomeEssenceRecipe.java
@@ -45,7 +45,7 @@ public class BiomeEssenceRecipe extends net.minecraftforge.registries.IForgeRegi
             }
         }
         
-        if (biomeRadar != null && biomeEssence != null)
+        if (biomeRadar != ItemStack.EMPTY && biomeEssence != ItemStack.EMPTY)
         {
             if (!biomeEssence.hasTagCompound() || !biomeEssence.getTagCompound().hasKey("biomeID")) return false;
             

--- a/src/main/java/biomesoplenty/common/crafting/BiomeEssenceRecipe.java
+++ b/src/main/java/biomesoplenty/common/crafting/BiomeEssenceRecipe.java
@@ -45,7 +45,7 @@ public class BiomeEssenceRecipe extends net.minecraftforge.registries.IForgeRegi
             }
         }
         
-        if (biomeRadar != ItemStack.EMPTY && biomeEssence != ItemStack.EMPTY)
+        if (!biomeRadar.isEmpty() && !biomeEssence.isEmpty())
         {
             if (!biomeEssence.hasTagCompound() || !biomeEssence.getTagCompound().hasKey("biomeID")) return false;
             


### PR DESCRIPTION
Here's a video illustrating the problem (set it to HD and watch the panel in the background as I move the 2 types of biome essence into the crafting grid):
https://youtu.be/lR7Sxcuiny4

The correct response is "oops" :D