### PR TITLE
Use Forge Registries to obtain Biome IDs and Biomes from ID

### DIFF
--- a/src/main/java/biomesoplenty/client/util/BiomeMapColours.java
+++ b/src/main/java/biomesoplenty/client/util/BiomeMapColours.java
@@ -17,9 +17,9 @@ import net.minecraft.client.renderer.model.BakedQuad;
 import net.minecraft.client.renderer.model.IBakedModel;
 import net.minecraft.util.Direction;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.registry.Registry;
 import net.minecraft.world.biome.Biome;
 import net.minecraftforge.common.BiomeDictionary;
+import biomesoplenty.common.util.biome.BiomeUtil;
 
 import java.nio.ByteBuffer;
 import java.security.MessageDigest;
@@ -102,7 +102,7 @@ public class BiomeMapColours
             return biomeColours.get(biomeId);
         }
 
-        int colour = getBiomeMapColourRaw(Registry.BIOME.byId(biomeId));
+        int colour = getBiomeMapColourRaw(BiomeUtil.GetBiomeFromID(biomeId));
         biomeColours.put(biomeId, colour);
         return colour;
     }

--- a/src/main/java/biomesoplenty/common/biome/BiomeBOP.java
+++ b/src/main/java/biomesoplenty/common/biome/BiomeBOP.java
@@ -8,6 +8,7 @@
 package biomesoplenty.common.biome;
 
 import biomesoplenty.api.enums.BOPClimates;
+import biomesoplenty.common.util.biome.BiomeUtil;
 import net.minecraft.util.registry.Registry;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.biome.Biomes;
@@ -26,8 +27,8 @@ public class BiomeBOP extends Biome
 {
     protected Map<BOPClimates, Integer> weightMap = new HashMap<BOPClimates, Integer>();
 	public boolean canSpawnInBiome;
-	public int beachBiomeId = Registry.BIOME.getId(Biomes.BEACH);
-	public int riverBiomeId = Registry.BIOME.getId(Biomes.RIVER);
+	public int beachBiomeId = BiomeUtil.GetBiomeIDFromRegistry(Biomes.BEACH.getRegistryName());
+	public int riverBiomeId = BiomeUtil.GetBiomeIDFromRegistry(Biomes.RIVER.getRegistryName());
 
     public BiomeBOP(Builder builder)
     {
@@ -43,7 +44,7 @@ public class BiomeBOP extends Biome
     public void setBeachBiome(Optional<Biome> biome)
     {
         if (biome.isPresent())
-            this.beachBiomeId = Registry.BIOME.getId(biome.get());
+            this.beachBiomeId = BiomeUtil.GetBiomeIDFromRegistry(biome.get().getRegistryName());
         else
             this.beachBiomeId = -1;
     }
@@ -51,7 +52,7 @@ public class BiomeBOP extends Biome
     public void setBeachBiome(Biome biome)
     {
         if (biome != null)
-            this.beachBiomeId = Registry.BIOME.getId(biome);
+            this.beachBiomeId = BiomeUtil.GetBiomeIDFromRegistry(biome.getRegistryName());
         else
             this.beachBiomeId = -1;
     }
@@ -59,7 +60,7 @@ public class BiomeBOP extends Biome
     public void setRiverBiome(Optional<Biome> biome)
     {
         if (biome.isPresent())
-            this.riverBiomeId = Registry.BIOME.getId(biome.get());
+            this.riverBiomeId = BiomeUtil.GetBiomeIDFromRegistry(biome.get().getRegistryName());
         else
             this.riverBiomeId = -1;
     }
@@ -67,7 +68,7 @@ public class BiomeBOP extends Biome
     public void setRiverBiome(Biome biome)
     {
         if (biome != null)
-            this.riverBiomeId = Registry.BIOME.getId(biome);
+            this.riverBiomeId = BiomeUtil.GetBiomeIDFromRegistry(biome.getRegistryName());
         else
             this.riverBiomeId = -1;
     }

--- a/src/main/java/biomesoplenty/common/biome/BiomeRegistry.java
+++ b/src/main/java/biomesoplenty/common/biome/BiomeRegistry.java
@@ -18,12 +18,12 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.gson.reflect.TypeToken;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.registry.Registry;
 import net.minecraft.world.biome.Biome;
 import net.minecraftforge.common.BiomeManager;
 import net.minecraftforge.fml.loading.FMLPaths;
 import net.minecraftforge.registries.ForgeRegistries;
 import org.apache.commons.lang3.tuple.Pair;
+import biomesoplenty.common.util.biome.BiomeUtil;
 
 import java.io.File;
 import java.nio.file.Path;
@@ -437,7 +437,7 @@ public class BiomeRegistry
 
             String childName = data.getChild().delegate.name().toString();
             BiomesOPlenty.logger.debug(String.format("Sub biome %s weight set to %d", childName, data.getWeight()));
-            ModBiomes.subBiomes.put(Registry.BIOME.getId(data.getParent()), new ModBiomes.WeightedSubBiome(data.getChild(), data.getRarity(), data.getWeight()));
+            ModBiomes.subBiomes.put(BiomeUtil.GetBiomeIDFromRegistry(data.getParent().getRegistryName()), new ModBiomes.WeightedSubBiome(data.getChild(), data.getRarity(), data.getWeight()));
         }),
         ISLAND_BIOME((SingleClimateRegistrationData data) -> {
             if (data.getWeight() == 0)
@@ -448,7 +448,7 @@ public class BiomeRegistry
 
             String biomeName = data.getBiome().delegate.name().toString();
             BiomesOPlenty.logger.debug(String.format("Island biome %s weight set to %d for climate %s", biomeName, data.getWeight(), data.getClimate().name()));
-            ModBiomes.islandBiomeIds.add(Registry.BIOME.getId(data.getBiome()));
+            ModBiomes.islandBiomeIds.add(BiomeUtil.GetBiomeIDFromRegistry(data.getBiome().getRegistryName()));
             data.getClimate().addIslandBiome(data.getWeight(), data.getBiome());
         }),
         VANILLA_BIOME((SingleClimateRegistrationData data) -> {

--- a/src/main/java/biomesoplenty/common/command/BiomeArgument.java
+++ b/src/main/java/biomesoplenty/common/command/BiomeArgument.java
@@ -17,10 +17,11 @@ import com.mojang.brigadier.suggestion.SuggestionsBuilder;
 import net.minecraft.command.CommandSource;
 import net.minecraft.command.ISuggestionProvider;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.registry.Registry;
 import net.minecraft.util.text.TranslationTextComponent;
 import net.minecraft.world.biome.Biome;
+import net.minecraftforge.registries.ForgeRegistries;
 
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 public class BiomeArgument implements ArgumentType<Biome>
@@ -43,7 +44,8 @@ public class BiomeArgument implements ArgumentType<Biome>
     public Biome parse(StringReader reader) throws CommandSyntaxException
     {
         ResourceLocation location = ResourceLocation.read(reader);
-        return Registry.BIOME.getOptional(location).orElseThrow(() ->
+        Optional<Biome> optional = Optional.ofNullable(ForgeRegistries.BIOMES.getValue(location));
+        return optional.orElseThrow(() ->
         {
             return INVALID_BIOME_EXCEPTION.create(location);
         });
@@ -52,6 +54,6 @@ public class BiomeArgument implements ArgumentType<Biome>
     @Override
     public <S> CompletableFuture<Suggestions> listSuggestions(CommandContext<S> context, SuggestionsBuilder suggestionsBuilder)
     {
-        return ISuggestionProvider.suggestResource(Registry.BIOME.keySet(), suggestionsBuilder);
+        return ISuggestionProvider.suggestResource(ForgeRegistries.BIOMES.getKeys(), suggestionsBuilder);
     }
 }

--- a/src/main/java/biomesoplenty/common/util/biome/BiomeUtil.java
+++ b/src/main/java/biomesoplenty/common/util/biome/BiomeUtil.java
@@ -9,16 +9,27 @@ package biomesoplenty.common.util.biome;
 
 import biomesoplenty.common.world.BOPOverworldGenSettings;
 import biomesoplenty.core.BiomesOPlenty;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
+import net.minecraftforge.registries.RegistryManager;
 
 public class BiomeUtil
 {
+    private static ResourceLocation BiomeRegistry = new ResourceLocation("biome");
     public static int getBiomeSize(World world)
     {
         // TODO
         return BOPOverworldGenSettings.BiomeSize.MEDIUM.getValue();
+    }
+    
+    public static int GetBiomeIDFromRegistry(ResourceLocation res) {
+        return RegistryManager.ACTIVE.getRegistry(BiomeRegistry).getID(res);
+    }
+    
+    public static Biome GetBiomeFromID(int id) {
+    	return (Biome)RegistryManager.ACTIVE.getRegistry(BiomeRegistry).getValue(id);
     }
 
     public static BlockPos spiralOutwardsLookingForBiome(World world, Biome biomeToFind, double startX, double startZ)

--- a/src/main/java/biomesoplenty/common/world/BOPLayerUtil.java
+++ b/src/main/java/biomesoplenty/common/world/BOPLayerUtil.java
@@ -7,9 +7,9 @@
  ******************************************************************************/
 package biomesoplenty.common.world;
 
+import biomesoplenty.common.util.biome.BiomeUtil;
 import biomesoplenty.common.world.layer.*;
 import biomesoplenty.common.world.layer.traits.LazyAreaLayerContextBOP;
-import net.minecraft.util.registry.Registry;
 import net.minecraft.world.WorldType;
 import net.minecraft.world.biome.Biomes;
 import net.minecraft.world.gen.IExtendedNoiseRandom;
@@ -22,16 +22,16 @@ import java.util.function.LongFunction;
 
 public class BOPLayerUtil
 {
-    public static final int WARM_OCEAN = Registry.BIOME.getId(Biomes.WARM_OCEAN);
-    public static final int LUKEWARM_OCEAN = Registry.BIOME.getId(Biomes.LUKEWARM_OCEAN);
-    public static final int OCEAN = Registry.BIOME.getId(Biomes.OCEAN);
-    public static final int COLD_OCEAN = Registry.BIOME.getId(Biomes.COLD_OCEAN);
-    public static final int FROZEN_OCEAN = Registry.BIOME.getId(Biomes.FROZEN_OCEAN);
-    public static final int DEEP_WARM_OCEAN = Registry.BIOME.getId(Biomes.DEEP_WARM_OCEAN);
-    public static final int DEEP_LUKEWARM_OCEAN = Registry.BIOME.getId(Biomes.DEEP_LUKEWARM_OCEAN);
-    public static final int DEEP_OCEAN = Registry.BIOME.getId(Biomes.DEEP_OCEAN);
-    public static final int DEEP_COLD_OCEAN = Registry.BIOME.getId(Biomes.DEEP_COLD_OCEAN);
-    public static final int DEEP_FROZEN_OCEAN = Registry.BIOME.getId(Biomes.DEEP_FROZEN_OCEAN);
+    public static final int WARM_OCEAN = BiomeUtil.GetBiomeIDFromRegistry(Biomes.WARM_OCEAN.getRegistryName());
+    public static final int LUKEWARM_OCEAN = BiomeUtil.GetBiomeIDFromRegistry(Biomes.LUKEWARM_OCEAN.getRegistryName());
+    public static final int OCEAN = BiomeUtil.GetBiomeIDFromRegistry(Biomes.OCEAN.getRegistryName());
+    public static final int COLD_OCEAN = BiomeUtil.GetBiomeIDFromRegistry(Biomes.COLD_OCEAN.getRegistryName());
+    public static final int FROZEN_OCEAN = BiomeUtil.GetBiomeIDFromRegistry(Biomes.FROZEN_OCEAN.getRegistryName());
+    public static final int DEEP_WARM_OCEAN = BiomeUtil.GetBiomeIDFromRegistry(Biomes.DEEP_WARM_OCEAN.getRegistryName());
+    public static final int DEEP_LUKEWARM_OCEAN = BiomeUtil.GetBiomeIDFromRegistry(Biomes.DEEP_LUKEWARM_OCEAN.getRegistryName());
+    public static final int DEEP_OCEAN = BiomeUtil.GetBiomeIDFromRegistry(Biomes.DEEP_OCEAN.getRegistryName());
+    public static final int DEEP_COLD_OCEAN = BiomeUtil.GetBiomeIDFromRegistry(Biomes.DEEP_COLD_OCEAN.getRegistryName());
+    public static final int DEEP_FROZEN_OCEAN = BiomeUtil.GetBiomeIDFromRegistry(Biomes.DEEP_FROZEN_OCEAN.getRegistryName());
 
     public static <T extends IArea, C extends IExtendedNoiseRandom<T>> IAreaFactory<T> createInitialLandAndSeaFactory(LongFunction<C> contextFactory)
     {

--- a/src/main/java/biomesoplenty/common/world/layer/BOPBiomeEdgeLayer.java
+++ b/src/main/java/biomesoplenty/common/world/layer/BOPBiomeEdgeLayer.java
@@ -8,7 +8,7 @@
 package biomesoplenty.common.world.layer;
 
 import biomesoplenty.api.biome.BOPBiomes;
-import net.minecraft.util.registry.Registry;
+import biomesoplenty.common.util.biome.BiomeUtil;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.biome.Biomes;
 import net.minecraft.world.gen.INoiseRandom;
@@ -21,22 +21,22 @@ public enum BOPBiomeEdgeLayer implements ICastleTransformer
 {
     INSTANCE;
 
-    private static final int DESERT = Registry.BIOME.getId(Biomes.DESERT);
-    private static final int MOUNTAINS = Registry.BIOME.getId(Biomes.MOUNTAINS);
-    private static final int WOODED_MOUNTAINS = Registry.BIOME.getId(Biomes.WOODED_MOUNTAINS);
-    private static final int SNOWY_TUNDRA = Registry.BIOME.getId(Biomes.SNOWY_TUNDRA);
-    private static final int JUNGLE = Registry.BIOME.getId(Biomes.JUNGLE);
-    private static final int JUNGLE_HILLS = Registry.BIOME.getId(Biomes.JUNGLE_HILLS);
-    private static final int JUNGLE_EDGE = Registry.BIOME.getId(Biomes.JUNGLE_EDGE);
-    private static final int BADLANDS = Registry.BIOME.getId(Biomes.BADLANDS);
-    private static final int BADLANDS_PLATEAU = Registry.BIOME.getId(Biomes.BADLANDS_PLATEAU);
-    private static final int WOODED_BADLANDS_PLATEAU = Registry.BIOME.getId(Biomes.WOODED_BADLANDS_PLATEAU);
-    private static final int PLAINS = Registry.BIOME.getId(Biomes.PLAINS);
-    private static final int GIANT_TREE_TAIGA = Registry.BIOME.getId(Biomes.GIANT_TREE_TAIGA);
-    private static final int MOUNTAIN_EDGE = Registry.BIOME.getId(Biomes.MOUNTAIN_EDGE);
-    private static final int SWAMP = Registry.BIOME.getId(Biomes.SWAMP);
-    private static final int TAIGA = Registry.BIOME.getId(Biomes.TAIGA);
-    private static final int SNOWY_TAIGA = Registry.BIOME.getId(Biomes.SNOWY_TAIGA);
+    private static final int DESERT = BiomeUtil.GetBiomeIDFromRegistry(Biomes.DESERT.getRegistryName());
+    private static final int MOUNTAINS = BiomeUtil.GetBiomeIDFromRegistry(Biomes.MOUNTAINS.getRegistryName());
+    private static final int WOODED_MOUNTAINS = BiomeUtil.GetBiomeIDFromRegistry(Biomes.WOODED_MOUNTAINS.getRegistryName());
+    private static final int SNOWY_TUNDRA = BiomeUtil.GetBiomeIDFromRegistry(Biomes.SNOWY_TUNDRA.getRegistryName());
+    private static final int JUNGLE = BiomeUtil.GetBiomeIDFromRegistry(Biomes.JUNGLE.getRegistryName());
+    private static final int JUNGLE_HILLS = BiomeUtil.GetBiomeIDFromRegistry(Biomes.JUNGLE_HILLS.getRegistryName());
+    private static final int JUNGLE_EDGE = BiomeUtil.GetBiomeIDFromRegistry(Biomes.JUNGLE_EDGE.getRegistryName());
+    private static final int BADLANDS = BiomeUtil.GetBiomeIDFromRegistry(Biomes.BADLANDS.getRegistryName());
+    private static final int BADLANDS_PLATEAU = BiomeUtil.GetBiomeIDFromRegistry(Biomes.BADLANDS_PLATEAU.getRegistryName());
+    private static final int WOODED_BADLANDS_PLATEAU = BiomeUtil.GetBiomeIDFromRegistry(Biomes.WOODED_BADLANDS_PLATEAU.getRegistryName());
+    private static final int PLAINS = BiomeUtil.GetBiomeIDFromRegistry(Biomes.PLAINS.getRegistryName());
+    private static final int GIANT_TREE_TAIGA = BiomeUtil.GetBiomeIDFromRegistry(Biomes.GIANT_TREE_TAIGA.getRegistryName());
+    private static final int MOUNTAIN_EDGE = BiomeUtil.GetBiomeIDFromRegistry(Biomes.MOUNTAIN_EDGE.getRegistryName());
+    private static final int SWAMP = BiomeUtil.GetBiomeIDFromRegistry(Biomes.SWAMP.getRegistryName());
+    private static final int TAIGA = BiomeUtil.GetBiomeIDFromRegistry(Biomes.TAIGA.getRegistryName());
+    private static final int SNOWY_TAIGA = BiomeUtil.GetBiomeIDFromRegistry(Biomes.SNOWY_TAIGA.getRegistryName());
 
     @Override
     public int apply(INoiseRandom context, int northBiomeId, int eastBiomeId, int southBiomeId, int westBiomeId, int biomeId)
@@ -108,12 +108,13 @@ public enum BOPBiomeEdgeLayer implements ICastleTransformer
 
     private boolean replaceBiomeEdge(int[] outId, int northBiomeId, int eastBiomeId, int southBiomeId, int westBiomeId, int biomeId, Optional<Biome> fromBiome, Optional<Biome> toBiome)
     {
-        return fromBiome.isPresent() && toBiome.isPresent() && this.replaceBiomeEdge(outId, northBiomeId, eastBiomeId, southBiomeId, westBiomeId, biomeId, Registry.BIOME.getId(fromBiome.get()), Registry.BIOME.getId(toBiome.get()));
+        return fromBiome.isPresent() && toBiome.isPresent() && this.replaceBiomeEdge(outId, northBiomeId, eastBiomeId, southBiomeId, westBiomeId, biomeId, BiomeUtil.GetBiomeIDFromRegistry(fromBiome.get().getRegistryName()), BiomeUtil.GetBiomeIDFromRegistry(toBiome.get().getRegistryName()));
     }
     
-    private boolean replaceBiomeEdge(int[] outId, int northBiomeId, int eastBiomeId, int southBiomeId, int westBiomeId, int biomeId, Optional<Biome> fromBiome, int toBiome)
+    @SuppressWarnings("unused")
+	private boolean replaceBiomeEdge(int[] outId, int northBiomeId, int eastBiomeId, int southBiomeId, int westBiomeId, int biomeId, Optional<Biome> fromBiome, int toBiome)
     {
-        return fromBiome.isPresent() && this.replaceBiomeEdge(outId, northBiomeId, eastBiomeId, southBiomeId, westBiomeId, biomeId, Registry.BIOME.getId(fromBiome.get()), toBiome);
+        return fromBiome.isPresent() && this.replaceBiomeEdge(outId, northBiomeId, eastBiomeId, southBiomeId, westBiomeId, biomeId, BiomeUtil.GetBiomeIDFromRegistry(fromBiome.get().getRegistryName()), toBiome);
     }
 
     private boolean replaceBiomeEdge(int[] outId, int northBiomeId, int eastBiomeId, int southBiomeId, int westBiomeId, int biomeId, int fromBiome, int toBiome)
@@ -145,8 +146,8 @@ public enum BOPBiomeEdgeLayer implements ICastleTransformer
         }
         else
         {
-            Biome biomeA = Registry.BIOME.byId(biomeIdA);
-            Biome biomeB = Registry.BIOME.byId(biomeIdB);
+            Biome biomeA = BiomeUtil.GetBiomeFromID(biomeIdA);
+            Biome biomeB = BiomeUtil.GetBiomeFromID(biomeIdB);
             if (biomeA != null && biomeB != null)
             {
                 Biome.TempCategory catA = biomeA.getTemperatureCategory();

--- a/src/main/java/biomesoplenty/common/world/layer/BOPBiomeLayer.java
+++ b/src/main/java/biomesoplenty/common/world/layer/BOPBiomeLayer.java
@@ -8,8 +8,8 @@
 package biomesoplenty.common.world.layer;
 
 import biomesoplenty.api.enums.BOPClimates;
+import biomesoplenty.common.util.biome.BiomeUtil;
 import biomesoplenty.init.ModBiomes;
-import net.minecraft.util.registry.Registry;
 import net.minecraft.world.biome.Biomes;
 import net.minecraft.world.gen.INoiseRandom;
 import net.minecraft.world.gen.area.IArea;
@@ -21,8 +21,8 @@ public enum BOPBiomeLayer implements IAreaTransformer2, IDimOffset0Transformer
 {
     INSTANCE;
 
-    private static final int DEEP_OCEAN = Registry.BIOME.getId(Biomes.DEEP_OCEAN);
-    private static final int MUSHROOM_FIELDS = Registry.BIOME.getId(Biomes.MUSHROOM_FIELDS);
+    private static final int DEEP_OCEAN = BiomeUtil.GetBiomeIDFromRegistry(Biomes.DEEP_OCEAN.getRegistryName());
+    private static final int MUSHROOM_FIELDS = BiomeUtil.GetBiomeIDFromRegistry(Biomes.MUSHROOM_FIELDS.getRegistryName());
 
     @Override
     public int applyPixel(INoiseRandom context, IArea area1, IArea area2, int x, int z)
@@ -47,7 +47,7 @@ public enum BOPBiomeLayer implements IAreaTransformer2, IDimOffset0Transformer
         // At this point, oceans and land have been assigned, and so have mushroom islands
         if (landSeaVal == DEEP_OCEAN)
         {
-            return Registry.BIOME.getId(climate.getRandomOceanBiome(context, true));
+            return BiomeUtil.GetBiomeIDFromRegistry(climate.getRandomOceanBiome(context, true).getRegistryName());
         }
         else if ((landSeaVal == MUSHROOM_FIELDS || ModBiomes.islandBiomeIds.contains(landSeaVal)) && climate.biomeType != BiomeManager.BiomeType.ICY) // TODO
         {
@@ -56,11 +56,11 @@ public enum BOPBiomeLayer implements IAreaTransformer2, IDimOffset0Transformer
         }
         else if (landSeaVal == 0)
         {
-            return Registry.BIOME.getId(climate.getRandomOceanBiome(context, false));
+            return BiomeUtil.GetBiomeIDFromRegistry(climate.getRandomOceanBiome(context, false).getRegistryName());
         }
         else
         {
-        	return Registry.BIOME.getId(climate.getRandomBiome(context, Biomes.OCEAN));
+        	return BiomeUtil.GetBiomeIDFromRegistry(climate.getRandomBiome(context, Biomes.OCEAN).getRegistryName());
         }
     }
 }

--- a/src/main/java/biomesoplenty/common/world/layer/BOPMixOceansLayer.java
+++ b/src/main/java/biomesoplenty/common/world/layer/BOPMixOceansLayer.java
@@ -9,9 +9,9 @@ package biomesoplenty.common.world.layer;
 
 import biomesoplenty.api.biome.BOPBiomes;
 import biomesoplenty.api.enums.BOPClimates;
+import biomesoplenty.common.util.biome.BiomeUtil;
 import biomesoplenty.common.world.BOPLayerUtil;
 import biomesoplenty.common.world.layer.traits.IAreaTransformer3;
-import net.minecraft.util.registry.Registry;
 import net.minecraft.world.biome.Biomes;
 import net.minecraft.world.gen.INoiseRandom;
 import net.minecraft.world.gen.area.IArea;
@@ -62,7 +62,7 @@ public enum BOPMixOceansLayer implements IAreaTransformer3, IDimOffset0Transform
                 case WASTELAND:
                     if (BOPBiomes.wasteland.isPresent())
                     {
-                        oceanId = Registry.BIOME.getId(BOPBiomes.wasteland.get());
+                        oceanId = BiomeUtil.GetBiomeIDFromRegistry(BOPBiomes.wasteland.get().getRegistryName());
                     }
                     // Fallthrough
 
@@ -120,9 +120,9 @@ public enum BOPMixOceansLayer implements IAreaTransformer3, IDimOffset0Transform
                     return BOPLayerUtil.DEEP_FROZEN_OCEAN;
                 }
 
-                if (BOPBiomes.wasteland.isPresent() && oceanId == Registry.BIOME.getId(BOPBiomes.wasteland.get()))
+                if (BOPBiomes.wasteland.isPresent() && oceanId == BiomeUtil.GetBiomeIDFromRegistry(BOPBiomes.wasteland.get().getRegistryName()))
                 {
-                    return Registry.BIOME.getId(BOPBiomes.wasteland.get());
+                    return BiomeUtil.GetBiomeIDFromRegistry(BOPBiomes.wasteland.get().getRegistryName());
                 }
             }
 

--- a/src/main/java/biomesoplenty/common/world/layer/BOPRiverMixLayer.java
+++ b/src/main/java/biomesoplenty/common/world/layer/BOPRiverMixLayer.java
@@ -8,8 +8,8 @@
 package biomesoplenty.common.world.layer;
 
 import biomesoplenty.common.biome.BiomeBOP;
+import biomesoplenty.common.util.biome.BiomeUtil;
 import biomesoplenty.common.world.BOPLayerUtil;
-import net.minecraft.util.registry.Registry;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.biome.Biomes;
 import net.minecraft.world.gen.INoiseRandom;
@@ -21,18 +21,18 @@ public enum BOPRiverMixLayer implements IAreaTransformer2, IDimOffset0Transforme
 {
     INSTANCE;
 
-    private static final int FROZEN_RIVER = Registry.BIOME.getId(Biomes.FROZEN_RIVER);
-    private static final int SNOWY_TUNDRA = Registry.BIOME.getId(Biomes.SNOWY_TUNDRA);
-    private static final int MUSHROOM_FIELDS = Registry.BIOME.getId(Biomes.MUSHROOM_FIELDS);
-    private static final int MUSHROOM_FIELD_SHORE = Registry.BIOME.getId(Biomes.MUSHROOM_FIELD_SHORE);
-    private static final int RIVER = Registry.BIOME.getId(Biomes.RIVER);
+    private static final int FROZEN_RIVER = BiomeUtil.GetBiomeIDFromRegistry(Biomes.FROZEN_RIVER.getRegistryName());
+    private static final int SNOWY_TUNDRA = BiomeUtil.GetBiomeIDFromRegistry(Biomes.SNOWY_TUNDRA.getRegistryName());
+    private static final int MUSHROOM_FIELDS = BiomeUtil.GetBiomeIDFromRegistry(Biomes.MUSHROOM_FIELDS.getRegistryName());
+    private static final int MUSHROOM_FIELD_SHORE = BiomeUtil.GetBiomeIDFromRegistry(Biomes.MUSHROOM_FIELD_SHORE.getRegistryName());
+    private static final int RIVER = BiomeUtil.GetBiomeIDFromRegistry(Biomes.RIVER.getRegistryName());
 
     @Override
     public int applyPixel(INoiseRandom context, IArea biomeArea, IArea riverArea, int x, int z)
     {
         int biomeId = biomeArea.get(x, z);
         int riverId = riverArea.get(x, z);
-        Biome biome = Registry.BIOME.byId(biomeId);
+        Biome biome = BiomeUtil.GetBiomeFromID(biomeId);
 
         if (BOPLayerUtil.isOcean(biomeId))
         {

--- a/src/main/java/biomesoplenty/common/world/layer/BOPShoreLayer.java
+++ b/src/main/java/biomesoplenty/common/world/layer/BOPShoreLayer.java
@@ -9,8 +9,8 @@ package biomesoplenty.common.world.layer;
 
 import biomesoplenty.api.biome.BOPBiomes;
 import biomesoplenty.common.biome.BiomeBOP;
+import biomesoplenty.common.util.biome.BiomeUtil;
 import biomesoplenty.common.world.BOPLayerUtil;
-import net.minecraft.util.registry.Registry;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.biome.Biomes;
 import net.minecraft.world.gen.INoiseRandom;
@@ -22,33 +22,33 @@ public enum BOPShoreLayer implements ICastleTransformer
 {
     INSTANCE;
 
-    private static final int BEACH = Registry.BIOME.getId(Biomes.BEACH);
-    private static final int SNOWY_BEACH = Registry.BIOME.getId(Biomes.SNOWY_BEACH);
-    private static final int DESERT = Registry.BIOME.getId(Biomes.DESERT);
-    private static final int MOUNTAINS = Registry.BIOME.getId(Biomes.MOUNTAINS);
-    private static final int WOODED_MOUNTAINS = Registry.BIOME.getId(Biomes.WOODED_MOUNTAINS);
-    private static final int FOREST = Registry.BIOME.getId(Biomes.FOREST);
-    private static final int JUNGLE = Registry.BIOME.getId(Biomes.JUNGLE);
-    private static final int JUNGLE_EDGE = Registry.BIOME.getId(Biomes.JUNGLE_EDGE);
-    private static final int JUNGLE_HILLS = Registry.BIOME.getId(Biomes.JUNGLE_HILLS);
-    private static final int BADLANDS = Registry.BIOME.getId(Biomes.BADLANDS);
-    private static final int WOODED_BADLANDS_PLATEAU = Registry.BIOME.getId(Biomes.WOODED_BADLANDS_PLATEAU);
-    private static final int BADLANDS_PLATEAU = Registry.BIOME.getId(Biomes.BADLANDS_PLATEAU);
-    private static final int ERODED_BADLANDS = Registry.BIOME.getId(Biomes.ERODED_BADLANDS);
-    private static final int MODIFIED_WOODED_BADLANDS_PLATEAU = Registry.BIOME.getId(Biomes.MODIFIED_WOODED_BADLANDS_PLATEAU);
-    private static final int MODIFIED_BADLANDS_PLATEAU = Registry.BIOME.getId(Biomes.MODIFIED_BADLANDS_PLATEAU);
-    private static final int MUSHROOM_FIELDS = Registry.BIOME.getId(Biomes.MUSHROOM_FIELDS);
-    private static final int MUSHROOM_FIELD_SHORE = Registry.BIOME.getId(Biomes.MUSHROOM_FIELD_SHORE);
-    private static final int RIVER = Registry.BIOME.getId(Biomes.RIVER);
-    private static final int MOUNTAIN_EDGE = Registry.BIOME.getId(Biomes.MOUNTAIN_EDGE);
-    private static final int STONE_SHORE = Registry.BIOME.getId(Biomes.STONE_SHORE);
-    private static final int SWAMP = Registry.BIOME.getId(Biomes.SWAMP);
-    private static final int TAIGA = Registry.BIOME.getId(Biomes.TAIGA);
+    private static final int BEACH = BiomeUtil.GetBiomeIDFromRegistry(Biomes.BEACH.getRegistryName());
+    private static final int SNOWY_BEACH = BiomeUtil.GetBiomeIDFromRegistry(Biomes.SNOWY_BEACH.getRegistryName());
+    private static final int DESERT = BiomeUtil.GetBiomeIDFromRegistry(Biomes.DESERT.getRegistryName());
+    private static final int MOUNTAINS = BiomeUtil.GetBiomeIDFromRegistry(Biomes.MOUNTAINS.getRegistryName());
+    private static final int WOODED_MOUNTAINS = BiomeUtil.GetBiomeIDFromRegistry(Biomes.WOODED_MOUNTAINS.getRegistryName());
+    private static final int FOREST = BiomeUtil.GetBiomeIDFromRegistry(Biomes.FOREST.getRegistryName());
+    private static final int JUNGLE = BiomeUtil.GetBiomeIDFromRegistry(Biomes.JUNGLE.getRegistryName());
+    private static final int JUNGLE_EDGE = BiomeUtil.GetBiomeIDFromRegistry(Biomes.JUNGLE_EDGE.getRegistryName());
+    private static final int JUNGLE_HILLS = BiomeUtil.GetBiomeIDFromRegistry(Biomes.JUNGLE_HILLS.getRegistryName());
+    private static final int BADLANDS = BiomeUtil.GetBiomeIDFromRegistry(Biomes.BADLANDS.getRegistryName());
+    private static final int WOODED_BADLANDS_PLATEAU = BiomeUtil.GetBiomeIDFromRegistry(Biomes.WOODED_BADLANDS_PLATEAU.getRegistryName());
+    private static final int BADLANDS_PLATEAU = BiomeUtil.GetBiomeIDFromRegistry(Biomes.BADLANDS_PLATEAU.getRegistryName());
+    private static final int ERODED_BADLANDS = BiomeUtil.GetBiomeIDFromRegistry(Biomes.ERODED_BADLANDS.getRegistryName());
+    private static final int MODIFIED_WOODED_BADLANDS_PLATEAU = BiomeUtil.GetBiomeIDFromRegistry(Biomes.MODIFIED_WOODED_BADLANDS_PLATEAU.getRegistryName());
+    private static final int MODIFIED_BADLANDS_PLATEAU = BiomeUtil.GetBiomeIDFromRegistry(Biomes.MODIFIED_BADLANDS_PLATEAU.getRegistryName());
+    private static final int MUSHROOM_FIELDS = BiomeUtil.GetBiomeIDFromRegistry(Biomes.MUSHROOM_FIELDS.getRegistryName());
+    private static final int MUSHROOM_FIELD_SHORE = BiomeUtil.GetBiomeIDFromRegistry(Biomes.MUSHROOM_FIELD_SHORE.getRegistryName());
+    private static final int RIVER = BiomeUtil.GetBiomeIDFromRegistry(Biomes.RIVER.getRegistryName());
+    private static final int MOUNTAIN_EDGE = BiomeUtil.GetBiomeIDFromRegistry(Biomes.MOUNTAIN_EDGE.getRegistryName());
+    private static final int STONE_SHORE = BiomeUtil.GetBiomeIDFromRegistry(Biomes.STONE_SHORE.getRegistryName());
+    private static final int SWAMP = BiomeUtil.GetBiomeIDFromRegistry(Biomes.SWAMP.getRegistryName());
+    private static final int TAIGA = BiomeUtil.GetBiomeIDFromRegistry(Biomes.TAIGA.getRegistryName());
 
     @Override
     public int apply(INoiseRandom context, int northBiomeId, int eastBiomeId, int southBiomeId, int westBiomeId, int biomeId)
     {
-        Biome biome = Registry.BIOME.byId(biomeId);
+        Biome biome = BiomeUtil.GetBiomeFromID(biomeId);
 
         if (biomeId == MUSHROOM_FIELDS)
         {
@@ -133,12 +133,12 @@ public enum BOPShoreLayer implements ICastleTransformer
 
     private static int getBiomeIdIfPresent(Optional<Biome> biome, int fallbackId)
     {
-        return biome.isPresent() ? Registry.BIOME.getId(biome.get()) : fallbackId;
+        return biome.isPresent() ? BiomeUtil.GetBiomeIDFromRegistry(biome.get().getRegistryName()) : fallbackId;
     }
 
     private static boolean isJungleCompatible(int biomeId)
     {
-        if (Registry.BIOME.byId(biomeId) != null && (Registry.BIOME.byId(biomeId)).getBiomeCategory() == Biome.Category.JUNGLE)
+        if (BiomeUtil.GetBiomeFromID(biomeId) != null && (BiomeUtil.GetBiomeFromID(biomeId)).getBiomeCategory() == Biome.Category.JUNGLE)
         {
             return true;
         }

--- a/src/main/java/biomesoplenty/common/world/layer/LargeIslandLayer.java
+++ b/src/main/java/biomesoplenty/common/world/layer/LargeIslandLayer.java
@@ -8,7 +8,7 @@
 package biomesoplenty.common.world.layer;
 
 import biomesoplenty.api.enums.BOPClimates;
-import net.minecraft.util.registry.Registry;
+import biomesoplenty.common.util.biome.BiomeUtil;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.gen.INoiseRandom;
 import net.minecraft.world.gen.area.IArea;
@@ -53,7 +53,7 @@ public enum LargeIslandLayer implements IAreaTransformer2, IDimOffset1Transforme
             }
             else
             {
-                return Registry.BIOME.getId(islandBiome);
+                return BiomeUtil.GetBiomeIDFromRegistry(islandBiome.getRegistryName());
             }
         }
         else return centerVal;

--- a/src/main/java/biomesoplenty/common/world/layer/NetherBiomeLayer.java
+++ b/src/main/java/biomesoplenty/common/world/layer/NetherBiomeLayer.java
@@ -8,7 +8,7 @@
 package biomesoplenty.common.world.layer;
 
 import biomesoplenty.api.enums.BOPClimates;
-import net.minecraft.util.registry.Registry;
+import biomesoplenty.common.util.biome.BiomeUtil;
 import net.minecraft.world.biome.Biomes;
 import net.minecraft.world.gen.INoiseRandom;
 import net.minecraft.world.gen.layer.traits.IAreaTransformer0;
@@ -21,6 +21,6 @@ public enum NetherBiomeLayer implements IAreaTransformer0, IDimOffset0Transforme
     @Override
     public int applyPixel(INoiseRandom context, int x, int z)
     {
-        return Registry.BIOME.getId(BOPClimates.NETHER.getRandomBiome(context, Biomes.NETHER));
+        return BiomeUtil.GetBiomeIDFromRegistry(BOPClimates.NETHER.getRandomBiome(context, Biomes.NETHER).getRegistryName());
     }
 }

--- a/src/main/java/biomesoplenty/common/world/layer/SubBiomeLayer.java
+++ b/src/main/java/biomesoplenty/common/world/layer/SubBiomeLayer.java
@@ -10,10 +10,10 @@ package biomesoplenty.common.world.layer;
 
 import biomesoplenty.api.biome.BOPBiomes;
 import biomesoplenty.api.enums.BOPClimates;
+import biomesoplenty.common.util.biome.BiomeUtil;
 import biomesoplenty.common.world.BOPLayerUtil;
 import biomesoplenty.init.ModBiomes;
 import com.google.common.collect.Lists;
-import net.minecraft.util.registry.Registry;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.biome.Biomes;
 import net.minecraft.world.gen.INoiseRandom;
@@ -29,32 +29,32 @@ public enum SubBiomeLayer implements IAreaTransformer2, IDimOffset1Transformer
 {
     INSTANCE;
 
-    private static final int BIRCH_FOREST = Registry.BIOME.getId(Biomes.BIRCH_FOREST);
-    private static final int BIRCH_FOREST_HILLS = Registry.BIOME.getId(Biomes.BIRCH_FOREST_HILLS);
-    private static final int DESERT = Registry.BIOME.getId(Biomes.DESERT);
-    private static final int DESERT_HILLS = Registry.BIOME.getId(Biomes.DESERT_HILLS);
-    private static final int MOUNTAINS = Registry.BIOME.getId(Biomes.MOUNTAINS);
-    private static final int WOODED_MOUNTAINS = Registry.BIOME.getId(Biomes.WOODED_MOUNTAINS);
-    private static final int FOREST = Registry.BIOME.getId(Biomes.FOREST);
-    private static final int WOODED_HILLS = Registry.BIOME.getId(Biomes.WOODED_HILLS);
-    private static final int SNOWY_TUNDRA = Registry.BIOME.getId(Biomes.SNOWY_TUNDRA);
-    private static final int SNOWY_MOUNTAINS = Registry.BIOME.getId(Biomes.SNOWY_MOUNTAINS);
-    private static final int JUNGLE = Registry.BIOME.getId(Biomes.JUNGLE);
-    private static final int JUNGLE_HILLS = Registry.BIOME.getId(Biomes.JUNGLE_HILLS);
-    private static final int BAMBOO_JUNGLE = Registry.BIOME.getId(Biomes.BAMBOO_JUNGLE);
-    private static final int BAMBOO_JUNGLE_HILLS = Registry.BIOME.getId(Biomes.BAMBOO_JUNGLE_HILLS);
-    private static final int BADLANDS = Registry.BIOME.getId(Biomes.BADLANDS);
-    private static final int WOODED_BADLANDS_PLATEAU = Registry.BIOME.getId(Biomes.WOODED_BADLANDS_PLATEAU);
-    private static final int PLAINS = Registry.BIOME.getId(Biomes.PLAINS);
-    private static final int GIANT_TREE_TAIGA = Registry.BIOME.getId(Biomes.GIANT_TREE_TAIGA);
-    private static final int GIANT_TREE_TAIGA_HILLS = Registry.BIOME.getId(Biomes.GIANT_TREE_TAIGA_HILLS);
-    private static final int DARK_FOREST = Registry.BIOME.getId(Biomes.DARK_FOREST);
-    private static final int SAVANNA = Registry.BIOME.getId(Biomes.SAVANNA);
-    private static final int SAVANA_PLATEAU = Registry.BIOME.getId(Biomes.SAVANNA_PLATEAU);
-    private static final int TAIGA = Registry.BIOME.getId(Biomes.TAIGA);
-    private static final int SNOWY_TAIGA = Registry.BIOME.getId(Biomes.SNOWY_TAIGA);
-    private static final int SNOWY_TAIGA_HILLS = Registry.BIOME.getId(Biomes.SNOWY_TAIGA_HILLS);
-    private static final int TAIGA_HILLS = Registry.BIOME.getId(Biomes.TAIGA_HILLS);
+    private static final int BIRCH_FOREST = BiomeUtil.GetBiomeIDFromRegistry(Biomes.BIRCH_FOREST.getRegistryName());
+    private static final int BIRCH_FOREST_HILLS = BiomeUtil.GetBiomeIDFromRegistry(Biomes.BIRCH_FOREST_HILLS.getRegistryName());
+    private static final int DESERT = BiomeUtil.GetBiomeIDFromRegistry(Biomes.DESERT.getRegistryName());
+    private static final int DESERT_HILLS = BiomeUtil.GetBiomeIDFromRegistry(Biomes.DESERT_HILLS.getRegistryName());
+    private static final int MOUNTAINS = BiomeUtil.GetBiomeIDFromRegistry(Biomes.MOUNTAINS.getRegistryName());
+    private static final int WOODED_MOUNTAINS = BiomeUtil.GetBiomeIDFromRegistry(Biomes.WOODED_MOUNTAINS.getRegistryName());
+    private static final int FOREST = BiomeUtil.GetBiomeIDFromRegistry(Biomes.FOREST.getRegistryName());
+    private static final int WOODED_HILLS = BiomeUtil.GetBiomeIDFromRegistry(Biomes.WOODED_HILLS.getRegistryName());
+    private static final int SNOWY_TUNDRA = BiomeUtil.GetBiomeIDFromRegistry(Biomes.SNOWY_TUNDRA.getRegistryName());
+    private static final int SNOWY_MOUNTAINS = BiomeUtil.GetBiomeIDFromRegistry(Biomes.SNOWY_MOUNTAINS.getRegistryName());
+    private static final int JUNGLE = BiomeUtil.GetBiomeIDFromRegistry(Biomes.JUNGLE.getRegistryName());
+    private static final int JUNGLE_HILLS = BiomeUtil.GetBiomeIDFromRegistry(Biomes.JUNGLE_HILLS.getRegistryName());
+    private static final int BAMBOO_JUNGLE = BiomeUtil.GetBiomeIDFromRegistry(Biomes.BAMBOO_JUNGLE.getRegistryName());
+    private static final int BAMBOO_JUNGLE_HILLS = BiomeUtil.GetBiomeIDFromRegistry(Biomes.BAMBOO_JUNGLE_HILLS.getRegistryName());
+    private static final int BADLANDS = BiomeUtil.GetBiomeIDFromRegistry(Biomes.BADLANDS.getRegistryName());
+    private static final int WOODED_BADLANDS_PLATEAU = BiomeUtil.GetBiomeIDFromRegistry(Biomes.WOODED_BADLANDS_PLATEAU.getRegistryName());
+    private static final int PLAINS = BiomeUtil.GetBiomeIDFromRegistry(Biomes.PLAINS.getRegistryName());
+    private static final int GIANT_TREE_TAIGA = BiomeUtil.GetBiomeIDFromRegistry(Biomes.GIANT_TREE_TAIGA.getRegistryName());
+    private static final int GIANT_TREE_TAIGA_HILLS = BiomeUtil.GetBiomeIDFromRegistry(Biomes.GIANT_TREE_TAIGA_HILLS.getRegistryName());
+    private static final int DARK_FOREST = BiomeUtil.GetBiomeIDFromRegistry(Biomes.DARK_FOREST.getRegistryName());
+    private static final int SAVANNA = BiomeUtil.GetBiomeIDFromRegistry(Biomes.SAVANNA.getRegistryName());
+    private static final int SAVANA_PLATEAU = BiomeUtil.GetBiomeIDFromRegistry(Biomes.SAVANNA_PLATEAU.getRegistryName());
+    private static final int TAIGA = BiomeUtil.GetBiomeIDFromRegistry(Biomes.TAIGA.getRegistryName());
+    private static final int SNOWY_TAIGA = BiomeUtil.GetBiomeIDFromRegistry(Biomes.SNOWY_TAIGA.getRegistryName());
+    private static final int SNOWY_TAIGA_HILLS = BiomeUtil.GetBiomeIDFromRegistry(Biomes.SNOWY_TAIGA_HILLS.getRegistryName());
+    private static final int TAIGA_HILLS = BiomeUtil.GetBiomeIDFromRegistry(Biomes.TAIGA_HILLS.getRegistryName());
 
     @Override
     public int applyPixel(INoiseRandom context, IArea biomeArea, IArea riverAndSubBiomesInitArea, int x, int z)
@@ -69,10 +69,10 @@ public enum SubBiomeLayer implements IAreaTransformer2, IDimOffset1Transformer
         Biome mutatedBiome;
         if (!BOPLayerUtil.isShallowOcean(biomeId) && initVal >= 2 && tryRareBiome)
         {
-            Biome biome = Registry.BIOME.byId(biomeId);
+            Biome biome = BiomeUtil.GetBiomeFromID(biomeId);
             if (biome == null || !biome.isMutated()) {
                 mutatedBiome = Biome.getMutatedVariant(biome);
-                return mutatedBiome == null ? biomeId : Registry.BIOME.getId(mutatedBiome);
+                return mutatedBiome == null ? biomeId : BiomeUtil.GetBiomeIDFromRegistry(mutatedBiome.getRegistryName());
             }
         }
 
@@ -87,8 +87,8 @@ public enum SubBiomeLayer implements IAreaTransformer2, IDimOffset1Transformer
 
             if (subBiomeType == 0 && mutatedBiomeId != biomeId)
             {
-                mutatedBiome = Biome.getMutatedVariant(Registry.BIOME.byId(mutatedBiomeId));
-                mutatedBiomeId = mutatedBiome == null ? biomeId : Registry.BIOME.getId(mutatedBiome);
+                mutatedBiome = Biome.getMutatedVariant(BiomeUtil.GetBiomeFromID(mutatedBiomeId));
+                mutatedBiomeId = mutatedBiome == null ? biomeId : BiomeUtil.GetBiomeIDFromRegistry(mutatedBiome.getRegistryName());
             }
 
             if (mutatedBiomeId != biomeId)
@@ -141,7 +141,7 @@ public enum SubBiomeLayer implements IAreaTransformer2, IDimOffset1Transformer
         }
         while (weight >= 0);
 
-        selectedBiomeId = Registry.BIOME.getId(item.biome);
+        selectedBiomeId = BiomeUtil.GetBiomeIDFromRegistry(item.biome.getRegistryName());
         return selectedBiomeId;
     }
 
@@ -157,7 +157,7 @@ public enum SubBiomeLayer implements IAreaTransformer2, IDimOffset1Transformer
         else if (originalBiomeId == SNOWY_TAIGA) mutatedBiomeId = SNOWY_TAIGA_HILLS;
         //Use BOP orchard instead of vanilla forest
         //else if (originalBiomeId == PLAINS) mutatedBiomeId = context.random(3) == 0 ? WOODED_HILLS : FOREST;
-        else if (originalBiomeId == PLAINS && BOPBiomes.orchard.isPresent()) mutatedBiomeId = Registry.BIOME.getId(BOPBiomes.orchard.get());
+        else if (originalBiomeId == PLAINS && BOPBiomes.orchard.isPresent()) mutatedBiomeId = BiomeUtil.GetBiomeIDFromRegistry(BOPBiomes.orchard.get().getRegistryName());
         //////////
         else if (originalBiomeId == SNOWY_TUNDRA) mutatedBiomeId = SNOWY_MOUNTAINS;
         else if (originalBiomeId == JUNGLE) mutatedBiomeId = JUNGLE_HILLS;


### PR DESCRIPTION
Created two new utility functions in common.util.biome.BiomeUtil that utilize the Forge registries to obtain a Biome ID from it's ResourceLocation, and to create a Biome from a Biome ID respectively. Replaced all found references to Registry.BIOME.getId() and Registry.BIOME.byId() with these utility functions in an effort to clean up the code base and to stop using depreciated means of registry access.