### PR TITLE
Enhance ModCompatibility class to also register Nether biomes

### DIFF
--- a/src/main/java/biomesoplenty/api/enums/BOPClimates.java
+++ b/src/main/java/biomesoplenty/api/enums/BOPClimates.java
@@ -41,6 +41,7 @@ public enum BOPClimates
     WASTELAND (null),
     NETHER (null);
 
+    private static Set<Biome> registeredBiomes = Sets.newHashSet();
     public final BiomeType biomeType;
     private int totalBiomesWeight;
     private int totalIslandBiomesWeight;
@@ -53,6 +54,10 @@ public enum BOPClimates
         this.biomeType = biomeType;
     }
 
+    public static ImmutableSet<Biome> getRegisteredBiomes() {
+        return ImmutableSet.copyOf(registeredBiomes);
+    }
+
     public BOPClimates addBiome(int weight, Biome biome)
     {
         return this.addBiome(new WeightedBiomeEntry(weight, biome));
@@ -60,6 +65,7 @@ public enum BOPClimates
 
     public BOPClimates addBiome(WeightedBiomeEntry biomeEntry)
     {
+        registeredBiomes.add(biomeEntry.biome);
         this.totalBiomesWeight += biomeEntry.weight;
         this.landBiomes.add(biomeEntry);
         return this;
@@ -72,6 +78,7 @@ public enum BOPClimates
 
     public BOPClimates addIslandBiome(WeightedBiomeEntry biomeEntry)
     {
+        registeredBiomes.add(biomeEntry.biome);
         this.totalIslandBiomesWeight += biomeEntry.weight;
         this.islandBiomes.add(biomeEntry);
         return this;

--- a/src/main/java/biomesoplenty/api/enums/BOPClimates.java
+++ b/src/main/java/biomesoplenty/api/enums/BOPClimates.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2014-2019, the Biomes O' Plenty Team
+ * Copyright 2014-2020, the Biomes O' Plenty Team
  *
  * This work is licensed under a Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License.
  *
@@ -7,7 +7,6 @@
  ******************************************************************************/
 package biomesoplenty.api.enums;
 
-import biomesoplenty.api.biome.BOPBiomes;
 import biomesoplenty.init.ModBiomes;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;

--- a/src/main/java/biomesoplenty/init/ModCompatibility.java
+++ b/src/main/java/biomesoplenty/init/ModCompatibility.java
@@ -52,9 +52,9 @@ public class ModCompatibility
 
         /*
          * Support for nether biomes as the NETHER climate has a null BiomeType, making it impossible for modded nether biomes
-         * to be added to the climate by comparing BiomeTypes.
+         * to be added to the climate by comparing BiomeTypes, even if they provide a custom BiomeType for the entry.
          */
-        
+
         if (BiomeDictionary.hasType(biome, BiomeDictionary.Type.NETHER))
         {
             BOPClimates.NETHER.addBiome(weight, biome);

--- a/src/main/java/biomesoplenty/init/ModCompatibility.java
+++ b/src/main/java/biomesoplenty/init/ModCompatibility.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2014-2019, the Biomes O' Plenty Team
+ * Copyright 2014-2020, the Biomes O' Plenty Team
  *
  * This work is licensed under a Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License.
  *


### PR DESCRIPTION
Existing remap function made it impossible to scrape Nether biomes through the BiomeManager since the NETHER climate has a null BiomeType while the BiomeManager can't contain biomes with a null BiomeType. Now when remapping, ModCompatibility checks the BiomeDictionary for a NETHER type tag and if one exists it registers the biome with the NETHER climate to extend compatibility to nether biomes.

Also made a simplification to ModCompatibility similar to draft PR #1624 in that it no longer needs to use reflection to first get the vanilla entries to later remove from the collection, it now just uses the biomes registry name and its related namespace to ensure vanilla biomes are excluded, along with simplifications when checking against biomes possibly registered to a climate already through the API.