### PR TITLE
Change climate offsetting to random instead of bitmask

### DIFF
--- a/src/main/java/biomesoplenty/common/world/layer/RainfallNoiseLayer.java
+++ b/src/main/java/biomesoplenty/common/world/layer/RainfallNoiseLayer.java
@@ -7,6 +7,8 @@
  ******************************************************************************/
 package biomesoplenty.common.world.layer;
 
+import java.util.Random;
+
 import biomesoplenty.common.world.SimplexNoise;
 import biomesoplenty.common.world.layer.traits.IBOPAreaTransformer0;
 import biomesoplenty.common.world.layer.traits.IBOPContextExtended;
@@ -19,6 +21,10 @@ public enum RainfallNoiseLayer implements IBOPAreaTransformer0
 
     private final double scale;
 
+    private long seed;
+    private double xOffset;
+    private double zOffset;
+
     RainfallNoiseLayer(double scale)
     {
         this.scale = scale;
@@ -27,9 +33,17 @@ public enum RainfallNoiseLayer implements IBOPAreaTransformer0
     @Override
     public int applyPixel(IBOPContextExtended context, int x, int z)
     {
-        double xOffset = (double)(context.getWorldSeed() & 0xFFFFFF) * 0.000003D;
-        double zOffset = (double)(context.getWorldSeed() & 0xFFFFFF) * 0.000004D;
-        double noiseVal = SimplexNoise.noise((x + xOffset) * this.scale, (z + zOffset) * this.scale);
+        long seed = context.getWorldSeed();
+
+        // If the seed has changed, re-initialize offsets
+        if (this.seed != seed) {
+            Random random = new Random(seed - 123);
+            this.xOffset = random.nextDouble() * 128;
+            this.zOffset = random.nextDouble() * 128;
+            this.seed = seed;
+        }
+
+        double noiseVal = SimplexNoise.noise((x + this.xOffset) * this.scale, (z + this.zOffset) * this.scale);
 
         // boundaries were determined empirically by analyzing statistically output from the SimplexNoise function, and splitting into 12 equally likely groups
         if (noiseVal < -0.637D) return 0;

--- a/src/main/java/biomesoplenty/common/world/layer/TemperatureNoiseLayer.java
+++ b/src/main/java/biomesoplenty/common/world/layer/TemperatureNoiseLayer.java
@@ -7,6 +7,8 @@
  ******************************************************************************/
 package biomesoplenty.common.world.layer;
 
+import java.util.Random;
+
 import biomesoplenty.common.world.SimplexNoise;
 import biomesoplenty.common.world.layer.traits.IBOPAreaTransformer0;
 import biomesoplenty.common.world.layer.traits.IBOPContextExtended;
@@ -19,6 +21,10 @@ public enum TemperatureNoiseLayer implements IBOPAreaTransformer0
 
     private final double scale;
 
+    private long seed;
+    private double xOffset;
+    private double zOffset;
+
     TemperatureNoiseLayer(double scale)
     {
         this.scale = scale;
@@ -27,9 +33,17 @@ public enum TemperatureNoiseLayer implements IBOPAreaTransformer0
     @Override
     public int applyPixel(IBOPContextExtended context, int x, int z)
     {
-        double xOffset = (double)(context.getWorldSeed() & 0xFFFFFF) * 0.000001D;
-        double zOffset = (double)(context.getWorldSeed() & 0xFFFFFF) * 0.000002D;
-        double noiseVal = SimplexNoise.noise((x + xOffset) * this.scale, (z + zOffset) * this.scale);
+        long seed = context.getWorldSeed();
+
+        // If the seed has changed, re-initialize offsets
+        if (this.seed != seed) {
+            Random random = new Random(seed + 123);
+            this.xOffset = random.nextDouble() * 128;
+            this.zOffset = random.nextDouble() * 128;
+            this.seed = seed;
+        }
+
+        double noiseVal = SimplexNoise.noise((x + this.xOffset) * this.scale, (z + this.zOffset) * this.scale);
 
         // boundaries were determined empirically by analyzing statistically output from the SimplexNoise function, and splitting into 9 equally likely groups
         if (noiseVal < -0.619D) return 0;


### PR DESCRIPTION
This PR changes the climate offsetting to use Java Random's nextDouble to ensure that all climates will be generated in every seed.

Fixes #1648 