### PR TITLE
Fixes conflict with json dimensiontype files and nether structures being unlocatable

### DIFF
--- a/src/main/java/biomesoplenty/client/handler/GuiEventHandler.java
+++ b/src/main/java/biomesoplenty/client/handler/GuiEventHandler.java
@@ -92,7 +92,14 @@ public class GuiEventHandler
         if (isDataReadScreen(gui) && levelId != null && confirmScreen != null)
         {
             // Skip the confirm screen if this is the bop world type
-            if (isBopWorldType(mc, levelId))
+            //
+            // isBopWorldType is commented out because worldDataLoader.apply in createPackManager
+            // will break when any mod or datapack is on that uses json dimensiontypes. Why?
+            // I don't know. Might be due to being on the client thread instead of server? Maybe it
+            // is because this is being run before the server is made? Nevertheless, it may be best
+            // to just cancel the confirm screen completely or recommend people to use a different mod
+            // to always remove the confirm screen.
+            if (true) // isBopWorldType(mc, levelId))
             {
                 confirmScreen.listener.proceed(false, false);
             }

--- a/src/main/java/biomesoplenty/common/world/BOPNetherBiomeProvider.java
+++ b/src/main/java/biomesoplenty/common/world/BOPNetherBiomeProvider.java
@@ -43,7 +43,7 @@ public class BOPNetherBiomeProvider extends BiomeProvider
 
     public BOPNetherBiomeProvider(long seed, Registry<Biome> biomes)
     {
-        super(Stream.concat(VANILLA_POSSIBLE_BIOMES.stream(), BOPClimates.NETHER.getLandBiomes().stream().map((entry) -> entry.biome)).map(BiomeUtil::getBiome).collect(Collectors.toList()));
+        super(Stream.concat(VANILLA_POSSIBLE_BIOMES.stream(), BOPClimates.NETHER.getLandBiomes().stream().map((entry) -> entry.biome)).map(biomes::get).collect(Collectors.toList()));
         this.seed = seed;
         this.noiseBiomeLayer = BOPNetherLayerUtil.createGenLayers(seed);
         this.biomes = biomes;


### PR DESCRIPTION
The first issue was causing BoP to be unable to start up any world upon re-entering when any mod or datapack is on that has a dimensiontype json file. The issue seemed to be due to calling createPackManager's `worldDataLoader.apply` on the client before the world server is made. As to why? I do not know. Instead, I just set `if (isBopWorldType(mc, levelId))` to  `if (true)` to completely avoid the issue altogether as I could not find any suitable replacement for detecting if the save is a BoP save on the client. Sorry about that. But at least dimension mods and datapack will work again with BoP!
https://github.com/Glitchfiend/BiomesOPlenty/issues/1704

The second issue fixed was just changing the nether biome provider to use the datapack biomes instead of the worldgenregistries biomes. Now /locate command will look at the actual biome instance that other mods/datapack structures are added to and will be able to find that biome. (They always spawned before. Just /locate would fail for the above reason)
https://github.com/Glitchfiend/BiomesOPlenty/issues/1715