### PR TITLE
Added interop of hydroenergy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,15 @@ repositories {
         name 'Forge FS legacy'
         artifactPattern "http://files.minecraftforge.net/[module]/[module]-dev-[revision].[ext]"
     }
+maven {
+        url 'https://jitpack.io'
+    }
+}
+
+dependencies {
+    compile ("com.github.SinTh0r4s:HydroEnergy:master-SNAPSHOT:api") {
+        transitive = false
+    }
 }
 
 // define the properties file

--- a/src/main/java/biomesoplenty/client/fog/FogHandler.java
+++ b/src/main/java/biomesoplenty/client/fog/FogHandler.java
@@ -1,7 +1,9 @@
 package biomesoplenty.client.fog;
 
 import biomesoplenty.common.configuration.BOPConfigurationMisc;
-import com.sinthoras.hydroenergy.api.HEGetMaterialUtil;
+import com.sinthoras.hydroenergy.api.IHEHasCustomMaterialCalculation;
+import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.common.Optional;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.Minecraft;
@@ -26,6 +28,9 @@ import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 
 public class FogHandler 
 {
+	private static final String hydroenergy = "hydroenergy";
+	private static final boolean isHydroEnergyLoaded = Loader.isModLoaded(hydroenergy);
+
 	@SubscribeEvent
 	public void onGetFogColour(FogColors event)
 	{
@@ -50,7 +55,7 @@ public class FogHandler
 			}
 
 			Vec3 mixedColor;
-			if (HEGetMaterialUtil.getMaterialWrapper(blockAtEyes, event.entity.posY + event.entity.getEyeHeight()) == Material.water)
+			if (getMaterialWrapper(event) == Material.water)
 			{
 				mixedColor = getFogBlendColorWater(world, player, x, y, z, event.renderPartialTicks);
 			}
@@ -62,6 +67,26 @@ public class FogHandler
 			event.red = (float)mixedColor.xCoord;
 			event.green = (float)mixedColor.yCoord;
 			event.blue = (float)mixedColor.zCoord;
+		}
+	}
+
+	private Material getMaterialWrapper(EntityViewRenderEvent.FogColors event) {
+		if(isHydroEnergyLoaded) {
+			return getMaterialHEWrapper(event);
+		}
+		else {
+			return event.block.getMaterial();
+		}
+	}
+
+	@Optional.Method(modid = hydroenergy)
+	// Only required for '== Material.water' checks
+	private Material getMaterialHEWrapper(EntityViewRenderEvent.FogColors event) {
+		if(event.block instanceof IHEHasCustomMaterialCalculation) {
+			return ((IHEHasCustomMaterialCalculation)event.block).getMaterial(event.entity.posY + event.entity.getEyeHeight());
+		}
+		else {
+			return event.block.getMaterial();
 		}
 	}
 

--- a/src/main/java/biomesoplenty/client/fog/FogHandler.java
+++ b/src/main/java/biomesoplenty/client/fog/FogHandler.java
@@ -1,6 +1,7 @@
 package biomesoplenty.client.fog;
 
 import biomesoplenty.common.configuration.BOPConfigurationMisc;
+import com.sinthoras.hydroenergy.api.HEGetMaterialUtil;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.Minecraft;
@@ -49,7 +50,7 @@ public class FogHandler
 			}
 
 			Vec3 mixedColor;
-			if (blockAtEyes.getMaterial() == Material.water)
+			if (HEGetMaterialUtil.getMaterialWrapper(blockAtEyes, event.entity.posY + event.entity.getEyeHeight()) == Material.water)
 			{
 				mixedColor = getFogBlendColorWater(world, player, x, y, z, event.renderPartialTicks);
 			}


### PR DESCRIPTION
Hey,

I am working on a mod called [HydroEnergy](https://github.com/SinTh0r4s/HydroEnergy). It is a hydroelectric energy storage mod with realistic water levels. What i mean with that: [Demo Video](https://youtu.be/eUddgixexvI). Currently, i work on the deployment stuff and i am close to release. This is efficiently implemented in OpenGL and shaders, but requires to be a bit more flexible on the material. `getMaterial()` always returns `Material.water` and therefore, blocks that don't render as water are caught by the fog renderer as water. This looks nasty and is fixed with this little change.
If you don't want to update BOP any more i am happy to do it via ASM.

Cheers,
Sin