### PR TITLE
Improve simplex noise code and results, make it fully seedable.

### DIFF
--- a/src/main/java/biomesoplenty/common/world/SimplexNoise.java
+++ b/src/main/java/biomesoplenty/common/world/SimplexNoise.java
@@ -6,10 +6,9 @@ package biomesoplenty.common.world;
  * Based on example code by Stefan Gustavson (stegu@itn.liu.se).
  * Optimisations by Peter Eastman (peastman@drizzle.stanford.edu).
  * Better rank ordering method by Stefan Gustavson in 2012.
+ * Stateless seedability and improved gradients by K.jpg in 2021.
  *
- * This could be speeded up even further, but it's useful as it is.
- *
- * Version 2012-03-09
+ * This could be sped up even further, but it's useful as it is.
  *
  * This code was placed in the public domain by its original author,
  * Stefan Gustavson. You may use it as you see fit, but
@@ -17,41 +16,92 @@ package biomesoplenty.common.world;
  */
 public final class SimplexNoise {
 
-    private static Grad[] grad2 = {
-            new Grad(1, 1), new Grad(-1, 1), new Grad(1, -1), new Grad(-1, -1),
-            new Grad(1, 0), new Grad(-1, 0), new Grad(1, 0), new Grad(-1, 0),
-            new Grad(0, 1), new Grad(0, -1), new Grad(0, 1), new Grad(0, -1)
-    };
+    // Prime multipliers for each vertex coordinate, for the statelessly-seedable hash function.
+    private static final long PRIME_X = 0x53A3F72DEEC546F5L;
+    private static final long PRIME_Y = 0x5BCC226E9FA0BACBL;
 
-    private static short[] p = {151, 160, 137, 91, 90, 15, 131, 13, 201, 95, 96, 53, 194, 233, 7, 225, 140, 36, 103,
-            30, 69, 142, 8, 99, 37, 240, 21, 10, 23,
-            190, 6, 148, 247, 120, 234, 75, 0, 26, 197, 62, 94, 252, 219, 203, 117, 35, 11, 32, 57, 177, 33, 88, 237, 149, 56, 87, 174, 20, 125, 136, 171, 168,
-            68, 175, 74, 165, 71, 134, 139, 48, 27, 166, 77, 146, 158, 231, 83, 111, 229, 122, 60, 211, 133, 230, 220, 105, 92, 41, 55, 46, 245, 40, 244, 102,
-            143, 54, 65, 25, 63, 161, 1, 216, 80, 73, 209, 76, 132, 187, 208, 89, 18, 169, 200, 196, 135, 130, 116, 188, 159, 86, 164, 100, 109, 198, 173, 186,
-            3, 64, 52, 217, 226, 250, 124, 123, 5, 202, 38, 147, 118, 126, 255, 82, 85, 212, 207, 206, 59, 227, 47, 16, 58, 17, 182, 189, 28, 42, 223, 183,
-            170, 213, 119, 248, 152, 2, 44, 154, 163, 70, 221, 153, 101, 155, 167, 43, 172, 9, 129, 22, 39, 253, 19, 98, 108, 110, 79, 113, 224, 232, 178, 185,
-            112, 104, 218, 246, 97, 228, 251, 34, 242, 193, 238, 210, 144, 12, 191, 179, 162, 241, 81, 51, 145, 235, 249, 14, 239, 107, 49, 192, 214, 31, 181,
-            199, 106, 157, 184, 84, 204, 176, 115, 121, 50, 45, 127, 4, 150, 254, 138, 236, 205, 93, 222, 114, 67, 29, 24, 72, 243, 141, 128, 195, 78, 66, 215,
-            61, 156, 180};
+    // After extensive searching, I have not found any duplicated seeds when using this constant,
+    // if it is used in combination with large enough coordinate primes. If there are any repeat seeds,
+    // they're either incredibly rare, or they require very specific combinations of bit flipping to discover.
+    private static final long HASH_UNIQUIFIER = 0x7DF3BB00907DD40DL;
 
-    // To remove the need for index wrapping, double the permutation table length
-    private static short[] perm = new short[512];
-    private static short[] permMod12 = new short[512];
-    static {
-        for (int i = 0; i < 512; i++) {
-            perm[i] = p[i & 255];
-            permMod12[i] = (short) (perm[i] % 12);
-        }
-    }
-
-    // Skewing and unskewing factors for 2, 3, and 4 dimensions
+    // Skewing and unskewing factors for 2 dimensions
     private static final double F2 = 0.5 * (Math.sqrt(3.0) - 1.0);
     private static final double G2 = (3.0 - Math.sqrt(3.0)) / 6.0;
+
+    // For when you want to start the noise such that the origin isn't always zero.
+    // The center of the triangle in skewed space is [(0,0)+(1,0)+(1,1)]/3=(2/3,1/3)
+    // Then to convert to true coordinates, (2/3-t,1/3-t) where t=(1/3+2/3)*G2=G2
+    // These can also be swapped to start in the opposite triangle, though there's little practical difference.
+    public static final double TRIANGLE_START_X = (2.0 / 3.0) - G2;
+    public static final double TRIANGLE_START_Y = (1.0 / 3.0) - G2;
 
     /**
      * Deactivate constructor
      */
     private SimplexNoise() {
+    }
+
+    // 2D simplex noise
+    public static double noise(long seed, double xin, double yin) {
+        
+        // Skew the input space to determine which simplex cell we're in
+        double s = (xin + yin) * F2; // Hairy factor for 2D
+        int i = fastfloor(xin + s);
+        int j = fastfloor(yin + s);
+
+        // Unskew the cell origin back to (x,y) space
+        double t = (i + j) * G2;
+        double originX0 = i - t;
+        double originY0 = j - t;
+
+        // The x,y distances from the cell origin
+        double x0 = xin - originX0;
+        double y0 = yin - originY0;
+        
+        // For the 2D case, the simplex shape is an equilateral triangle.
+        // Determine which simplex we are in.
+        int i1, j1;
+        if (x0 > y0) {
+            // lower triangle, XY order: (0,0)->(1,0)->(1,1)
+            i1 = 1;
+            j1 = 0;
+        } else {
+            // upper triangle, YX order: (0,0)->(0,1)->(1,1)
+            i1 = 0;
+            j1 = 1;
+        }
+
+        // Offsets for middle and final corners in (x,y) unskewed coords
+        // A step of (1,0) in (i,j) means a step of (1-c,-c) in (x,y). For (0,1) it's (-c,1-c). c = (3-sqrt(3))/6
+        double x1 = x0 - i1 + G2;
+        double y1 = y0 - j1 + G2;
+        double x2 = x0 - (1.0 - 2.0 * G2);
+        double y2 = y0 - (1.0 - 2.0 * G2);
+
+        // Pre-multiply primes for the seeded coordinate hash
+        long xsvp = i * PRIME_X;
+        long ysvp = j * PRIME_Y;
+        
+        // Calculate the contribution from the three corners
+        double value = 0;
+        double t0 = 0.5 - x0 * x0 - y0 * y0;
+        if (t0 > 0) {
+            t0 *= t0;
+            value = t0 * t0 * grad(seed, xsvp, ysvp, x0, y0);
+        }
+        double t1 = 0.5 - x1 * x1 - y1 * y1;
+        if (t1 > 0) {
+            t1 *= t1;
+            value += t1 * t1 * grad(seed, xsvp + (-i1 & PRIME_X), ysvp + (-j1 & PRIME_Y), x1, y1);
+        }
+        double t2 = 0.5 - x2 * x2 - y2 * y2;
+        if (t2 > 0) {
+            t2 *= t2;
+            value += t2 * t2 * grad(seed, xsvp + PRIME_X, ysvp + PRIME_Y, x2, y2);
+        }
+
+        return value;
     }
 
     // This method is a *lot* faster than using (int)Math.floor(x)
@@ -60,92 +110,106 @@ public final class SimplexNoise {
         return x < xi ? xi - 1 : xi;
     }
 
-    private static double dot(Grad g, double x, double y) {
-        return g.x * x + g.y * y;
+    private static double grad(long seed, long xsvp, long ysvp, double dx, double dy) {
+        long hash = seed ^ xsvp ^ ysvp;
+        hash *= HASH_UNIQUIFIER;
+
+        // Make sure every bit contributes
+        hash ^= hash >> 31;
+        hash ^= hash >> 17;
+        hash ^= hash >> 9;
+
+        int index = (int)(hash & 0xFE);
+
+        return grads[index] * dx + grads[index | 1] * dy;
     }
 
-    // 2D simplex noise
-    public static double noise(double xin, double yin) {
+    // 24 gradients, repeated 5 times, + an octagon out of them repeated again to fill the gap
+    private static final float[] grads = {
+            0.130526192220052f,  0.99144486137381f,   0.38268343236509f,   0.923879532511287f,  0.608761429008721f,  0.793353340291235f,  0.793353340291235f,  0.608761429008721f,
+            0.923879532511287f,  0.38268343236509f,   0.99144486137381f,   0.130526192220051f,  0.99144486137381f,  -0.130526192220051f,  0.923879532511287f, -0.38268343236509f,
+            0.793353340291235f, -0.60876142900872f,   0.608761429008721f, -0.793353340291235f,  0.38268343236509f,  -0.923879532511287f,  0.130526192220052f, -0.99144486137381f,
+            -0.130526192220052f, -0.99144486137381f,  -0.38268343236509f,  -0.923879532511287f, -0.608761429008721f, -0.793353340291235f, -0.793353340291235f, -0.608761429008721f,
+            -0.923879532511287f, -0.38268343236509f,  -0.99144486137381f,  -0.130526192220052f, -0.99144486137381f,   0.130526192220051f, -0.923879532511287f,  0.38268343236509f,
+            -0.793353340291235f,  0.608761429008721f, -0.608761429008721f,  0.793353340291235f, -0.38268343236509f,   0.923879532511287f, -0.130526192220052f,  0.99144486137381f,
+            0.130526192220052f,  0.99144486137381f,   0.38268343236509f,   0.923879532511287f,  0.608761429008721f,  0.793353340291235f,  0.793353340291235f,  0.608761429008721f,
+            0.923879532511287f,  0.38268343236509f,   0.99144486137381f,   0.130526192220051f,  0.99144486137381f,  -0.130526192220051f,  0.923879532511287f, -0.38268343236509f,
+            0.793353340291235f, -0.60876142900872f,   0.608761429008721f, -0.793353340291235f,  0.38268343236509f,  -0.923879532511287f,  0.130526192220052f, -0.99144486137381f,
+            -0.130526192220052f, -0.99144486137381f,  -0.38268343236509f,  -0.923879532511287f, -0.608761429008721f, -0.793353340291235f, -0.793353340291235f, -0.608761429008721f,
+            -0.923879532511287f, -0.38268343236509f,  -0.99144486137381f,  -0.130526192220052f, -0.99144486137381f,   0.130526192220051f, -0.923879532511287f,  0.38268343236509f,
+            -0.793353340291235f,  0.608761429008721f, -0.608761429008721f,  0.793353340291235f, -0.38268343236509f,   0.923879532511287f, -0.130526192220052f,  0.99144486137381f,
+            0.130526192220052f,  0.99144486137381f,   0.38268343236509f,   0.923879532511287f,  0.608761429008721f,  0.793353340291235f,  0.793353340291235f,  0.608761429008721f,
+            0.923879532511287f,  0.38268343236509f,   0.99144486137381f,   0.130526192220051f,  0.99144486137381f,  -0.130526192220051f,  0.923879532511287f, -0.38268343236509f,
+            0.793353340291235f, -0.60876142900872f,   0.608761429008721f, -0.793353340291235f,  0.38268343236509f,  -0.923879532511287f,  0.130526192220052f, -0.99144486137381f,
+            -0.130526192220052f, -0.99144486137381f,  -0.38268343236509f,  -0.923879532511287f, -0.608761429008721f, -0.793353340291235f, -0.793353340291235f, -0.608761429008721f,
+            -0.923879532511287f, -0.38268343236509f,  -0.99144486137381f,  -0.130526192220052f, -0.99144486137381f,   0.130526192220051f, -0.923879532511287f,  0.38268343236509f,
+            -0.793353340291235f,  0.608761429008721f, -0.608761429008721f,  0.793353340291235f, -0.38268343236509f,   0.923879532511287f, -0.130526192220052f,  0.99144486137381f,
+            0.130526192220052f,  0.99144486137381f,   0.38268343236509f,   0.923879532511287f,  0.608761429008721f,  0.793353340291235f,  0.793353340291235f,  0.608761429008721f,
+            0.923879532511287f,  0.38268343236509f,   0.99144486137381f,   0.130526192220051f,  0.99144486137381f,  -0.130526192220051f,  0.923879532511287f, -0.38268343236509f,
+            0.793353340291235f, -0.60876142900872f,   0.608761429008721f, -0.793353340291235f,  0.38268343236509f,  -0.923879532511287f,  0.130526192220052f, -0.99144486137381f,
+            -0.130526192220052f, -0.99144486137381f,  -0.38268343236509f,  -0.923879532511287f, -0.608761429008721f, -0.793353340291235f, -0.793353340291235f, -0.608761429008721f,
+            -0.923879532511287f, -0.38268343236509f,  -0.99144486137381f,  -0.130526192220052f, -0.99144486137381f,   0.130526192220051f, -0.923879532511287f,  0.38268343236509f,
+            -0.793353340291235f,  0.608761429008721f, -0.608761429008721f,  0.793353340291235f, -0.38268343236509f,   0.923879532511287f, -0.130526192220052f,  0.99144486137381f,
+            0.130526192220052f,  0.99144486137381f,   0.38268343236509f,   0.923879532511287f,  0.608761429008721f,  0.793353340291235f,  0.793353340291235f,  0.608761429008721f,
+            0.923879532511287f,  0.38268343236509f,   0.99144486137381f,   0.130526192220051f,  0.99144486137381f,  -0.130526192220051f,  0.923879532511287f, -0.38268343236509f,
+            0.793353340291235f, -0.60876142900872f,   0.608761429008721f, -0.793353340291235f,  0.38268343236509f,  -0.923879532511287f,  0.130526192220052f, -0.99144486137381f,
+            -0.130526192220052f, -0.99144486137381f,  -0.38268343236509f,  -0.923879532511287f, -0.608761429008721f, -0.793353340291235f, -0.793353340291235f, -0.608761429008721f,
+            -0.923879532511287f, -0.38268343236509f,  -0.99144486137381f,  -0.130526192220052f, -0.99144486137381f,   0.130526192220051f, -0.923879532511287f,  0.38268343236509f,
+            -0.793353340291235f,  0.608761429008721f, -0.608761429008721f,  0.793353340291235f, -0.38268343236509f,   0.923879532511287f, -0.130526192220052f,  0.99144486137381f,
+            0.38268343236509f,   0.923879532511287f,  0.923879532511287f,  0.38268343236509f,   0.923879532511287f, -0.38268343236509f,   0.38268343236509f,  -0.923879532511287f,
+            -0.38268343236509f,  -0.923879532511287f, -0.923879532511287f, -0.38268343236509f,  -0.923879532511287f,  0.38268343236509f,  -0.38268343236509f,   0.923879532511287f,
+    };
 
-        double n0, n1, n2; // Noise contributions from the three corners
-        // Skew the input space to determine which simplex cell we're in
-        double s = (xin + yin) * F2; // Hairy factor for 2D
-        int i = fastfloor(xin + s);
-        int j = fastfloor(yin + s);
-        double t = (i + j) * G2;
-        double originX0 = i - t; // Unskew the cell origin back to (x,y) space
-        double originY0 = j - t;
-        double x0 = xin - originX0; // The x,y distances from the cell origin
-        double y0 = yin - originY0;
-        // For the 2D case, the simplex shape is an equilateral triangle.
-        // Determine which simplex we are in.
-        int i1, j1; // Offsets for second (middle) corner of simplex in (i,j) coords
-        if (x0 > y0) {
-            i1 = 1;
-            j1 = 0;
-        } else {
-            // lower triangle, XY order: (0,0)->(1,0)->(1,1)
-            i1 = 0;
-            j1 = 1;
-        } // upper triangle, YX order: (0,0)->(0,1)->(1,1)
-        // A step of (1,0) in (i,j) means a step of (1-c,-c) in (x,y), and
-        // a step of (0,1) in (i,j) means a step of (-c,1-c) in (x,y), where
-        // c = (3-sqrt(3))/6
-        double x1 = x0 - i1 + G2; // Offsets for middle corner in (x,y) unskewed coords
-        double y1 = y0 - j1 + G2;
-        double x2 = x0 - 1.0 + 2.0 * G2; // Offsets for last corner in (x,y) unskewed coords
-        double y2 = y0 - 1.0 + 2.0 * G2;
-        // Work out the hashed gradient indices of the three simplex corners
-        int ii = i & 255;
-        int jj = j & 255;
-        int gi0 = permMod12[ii + perm[jj]];
-        int gi1 = permMod12[ii + i1 + perm[jj + j1]];
-        int gi2 = permMod12[ii + 1 + perm[jj + 1]];
-        // Calculate the contribution from the three corners
-        double t0 = 0.5 - x0 * x0 - y0 * y0;
-        if (t0 < 0) {
-            n0 = 0.0;
-        } else {
-            t0 *= t0;
-            n0 = t0 * t0 * dot(grad2[gi0], x0, y0); // (x,y) of grad3 used for 2D gradient
-        }
-        double t1 = 0.5 - x1 * x1 - y1 * y1;
-        if (t1 < 0) {
-            n1 = 0.0;
-        } else {
-            t1 *= t1;
-            n1 = t1 * t1 * dot(grad2[gi1], x1, y1);
-        }
-        double t2 = 0.5 - x2 * x2 - y2 * y2;
-        if (t2 < 0) {
-            n2 = 0.0;
-        } else {
-            t2 *= t2;
-            n2 = t2 * t2 * dot(grad2[gi2], x2, y2);
-        }
-        // Add contributions from each corner to get the final noise value.
-        // The result is scaled to return values in the interval [-1,1].
-        return 70.0 * (n0 + n1 + n2);
-    }
-
-    // Inner class to speed up gradient computations
-    // (array access is a lot slower than member access)
-    private static class Grad {
-        double x, y;
-        Grad(double x, double y) {
-            this.x = x;
-            this.y = y;
+    // Normalize the output to a range of -1 to 1
+    private static final double N2 = 0.01001634121365712;
+    static {
+        for (int i = 0; i < grads.length; i++) {
+            grads[i] /= N2;
         }
     }
 
     public static void main(String[] args)
     {
-        double startX = 0.3543276545;
-        double startZ = 0.534523434;
-        double d = 0.11111;
-        for (int i = 0; i < 1000; i++)
-        {
-            System.out.println(SimplexNoise.noise(startX + d * i, startZ + d * i));
+        // Render in ascii
+        long renderSeed = 1349226349613393113L;
+        int width = 120;
+        int height = 28;
+        double freqX = 1.0 / 33.0;
+        double freqY = 1.0 / 12.0;
+        String grayscaleAscii = " .:-=+*#%@"; // http://paulbourke.net/dataformats/asciiart/
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                double noise = SimplexNoise.noise(renderSeed, x * freqX, y * freqY);
+                noise = noise * 0.5 + 0.5;
+                int asciiGrayscaleLevel = (int)(noise * grayscaleAscii.length());
+                if (asciiGrayscaleLevel < 0) asciiGrayscaleLevel = 0;
+                else if (asciiGrayscaleLevel > grayscaleAscii.length())
+                    asciiGrayscaleLevel = grayscaleAscii.length() - 1;
+                System.out.print(grayscaleAscii.charAt(asciiGrayscaleLevel));
+            }
+            System.out.println();
         }
+
+        // Generate dividing group code
+        int numGroups = 9;
+        int numEvalsPerGroup = 0x100000;
+        double evalAreaRange = 128;
+        int randomSeed = 12345;
+        java.util.Random coordRandom = new java.util.Random(randomSeed);
+        double[] evals = new double[numGroups * numEvalsPerGroup * 2];
+        for (int i = 0; i < evals.length; i += 2) {
+            double value = SimplexNoise.noise(coordRandom.nextLong(), coordRandom.nextDouble() * evalAreaRange, coordRandom.nextDouble() * evalAreaRange);
+            evals[i + 0] = value;
+            evals[i + 1] = -value;
+        }
+        java.util.Arrays.sort(evals);
+        for (int i = 0; i < numGroups - 1; i++) {
+            int boundIndex = (i + 1) * (numEvalsPerGroup * 2);
+            double bound = (evals[boundIndex] + evals[boundIndex - 1]) * 0.5;
+            if (i != 0) System.out.print("else ");
+            System.out.println("if (noiseVal < " + bound + ") return " + i + ";");
+        }
+        System.out.print("else return " + (numGroups - 1) + ";");
+
     }
 }

--- a/src/main/java/biomesoplenty/common/world/layer/RainfallNoiseLayer.java
+++ b/src/main/java/biomesoplenty/common/world/layer/RainfallNoiseLayer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2014-2019, the Biomes O' Plenty Team
+ * Copyright 2014-2021, the Biomes O' Plenty Team
  *
  * This work is licensed under a Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License.
  *
@@ -21,10 +21,6 @@ public enum RainfallNoiseLayer implements IBOPAreaTransformer0
 
     private final double scale;
 
-    private long seed;
-    private double xOffset;
-    private double zOffset;
-
     RainfallNoiseLayer(double scale)
     {
         this.scale = scale;
@@ -34,29 +30,20 @@ public enum RainfallNoiseLayer implements IBOPAreaTransformer0
     public int applyPixel(IBOPContextExtended context, int x, int z)
     {
         long seed = context.getWorldSeed();
+        double noiseVal = SimplexNoise.noise(seed ^ 0xE157A1DC3B2A298CL, x * this.scale + SimplexNoise.TRIANGLE_START_Y, z * this.scale + SimplexNoise.TRIANGLE_START_X);
 
-        // If the seed has changed, re-initialize offsets
-        if (this.seed != seed) {
-            Random random = new Random(seed - 123);
-            this.xOffset = (random.nextDouble() - 0.5) * 8192;
-            this.zOffset = (random.nextDouble() - 0.5) * 8192;
-            this.seed = seed;
-        }
-
-        double noiseVal = SimplexNoise.noise((x + this.xOffset) * this.scale, (z + this.zOffset) * this.scale);
-
-        // boundaries were determined empirically by analyzing statistically output from the SimplexNoise function, and splitting into 12 equally likely groups
-        if (noiseVal < -0.637D) return 0;
-        else if (noiseVal < -0.575D) return 1;
-        else if (noiseVal < -0.465D) return 2;
-        else if (noiseVal < -0.295D) return 3;
-        else if (noiseVal < -0.148D) return 4;
-        else if (noiseVal < -0.034D) return 5;
-        else if (noiseVal < 0.132D) return 6;
-        else if (noiseVal < 0.246D) return 7;
-        else if (noiseVal < 0.400D) return 8;
-        else if (noiseVal < 0.551D) return 9;
-        else if (noiseVal < 0.634D) return 10;
+        // boundaries were determined empirically by analyzing statistically the output from the SimplexNoise function, and splitting into 12 equally likely groups
+        if (noiseVal < -0.7804209166984755) return 0;
+        else if (noiseVal < -0.6263615214979332) return 1;
+        else if (noiseVal < -0.47131115810932966) return 2;
+        else if (noiseVal < -0.31471113670415907) return 3;
+        else if (noiseVal < -0.15717936237854807) return 4;
+        else if (noiseVal < 0.0) return 5;
+        else if (noiseVal < 0.15717936237854807) return 6;
+        else if (noiseVal < 0.31471113670415907) return 7;
+        else if (noiseVal < 0.47131115810932966) return 8;
+        else if (noiseVal < 0.6263615214979332) return 9;
+        else if (noiseVal < 0.7804209166984755) return 10;
         else return 11;
     }
 }

--- a/src/main/java/biomesoplenty/common/world/layer/TemperatureNoiseLayer.java
+++ b/src/main/java/biomesoplenty/common/world/layer/TemperatureNoiseLayer.java
@@ -1,13 +1,11 @@
 /*******************************************************************************
- * Copyright 2014-2019, the Biomes O' Plenty Team
+ * Copyright 2014-2021, the Biomes O' Plenty Team
  *
  * This work is licensed under a Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License.
  *
  * To view a copy of this license, visit http://creativecommons.org/licenses/by-nc-nd/4.0/.
  ******************************************************************************/
 package biomesoplenty.common.world.layer;
-
-import java.util.Random;
 
 import biomesoplenty.common.world.SimplexNoise;
 import biomesoplenty.common.world.layer.traits.IBOPAreaTransformer0;
@@ -21,10 +19,6 @@ public enum TemperatureNoiseLayer implements IBOPAreaTransformer0
 
     private final double scale;
 
-    private long seed;
-    private double xOffset;
-    private double zOffset;
-
     TemperatureNoiseLayer(double scale)
     {
         this.scale = scale;
@@ -34,26 +28,17 @@ public enum TemperatureNoiseLayer implements IBOPAreaTransformer0
     public int applyPixel(IBOPContextExtended context, int x, int z)
     {
         long seed = context.getWorldSeed();
+        double noiseVal = SimplexNoise.noise(seed ^ 0xAB1C154F2C586F42L, x * this.scale + SimplexNoise.TRIANGLE_START_X, z * this.scale + SimplexNoise.TRIANGLE_START_Y);
 
-        // If the seed has changed, re-initialize offsets
-        if (this.seed != seed) {
-            Random random = new Random(seed + 123);
-            this.xOffset = (random.nextDouble() - 0.5) * 8192;
-            this.zOffset = (random.nextDouble() - 0.5) * 8192;
-            this.seed = seed;
-        }
-
-        double noiseVal = SimplexNoise.noise((x + this.xOffset) * this.scale, (z + this.zOffset) * this.scale);
-
-        // boundaries were determined empirically by analyzing statistically output from the SimplexNoise function, and splitting into 9 equally likely groups
-        if (noiseVal < -0.619D) return 0;
-        else if (noiseVal < -0.503D) return 1;
-        else if (noiseVal < -0.293D) return 2;
-        else if (noiseVal < -0.120D) return 3;
-        else if (noiseVal < 0.085D) return 4;
-        else if (noiseVal < 0.252D) return 5;
-        else if (noiseVal < 0.467D) return 6;
-        else if (noiseVal < 0.619D) return 7;
+        // boundaries were determined empirically by analyzing statistically the output from the SimplexNoise function, and splitting into 9 equally likely groups
+        if (noiseVal < -0.7290668901192167) return 0;
+        else if (noiseVal < -0.5226116882660503) return 1;
+        else if (noiseVal < -0.31460282189018446) return 2;
+        else if (noiseVal < -0.10524117177898246) return 3;
+        else if (noiseVal < 0.10524117177898246) return 4;
+        else if (noiseVal < 0.31460282189018446) return 5;
+        else if (noiseVal < 0.5226116882660503) return 6;
+        else if (noiseVal < 0.7290668901192167) return 7;
         else return 8;
     }
 }


### PR DESCRIPTION
Improves contrast and gradient direction variation in the simplex noise used for temperature and rainfall pattern distributions. Also adds true seedable functionality, so the whole pattern changes per world instead of it shifting around. I updated the group bounds in the biome noise layers to match the new noise.

Current:
![image](https://user-images.githubusercontent.com/8829856/123748178-dcb28580-d881-11eb-9862-4d264b87dffe.png)

New:
![image](https://user-images.githubusercontent.com/8829856/123748190-e20fd000-d881-11eb-9ef8-3d13d080336c.png)

Bonus: Now when you run the main method in SimplexNoise.java through the dev console, you get this:
![image](https://user-images.githubusercontent.com/8829856/123748660-7a0db980-d882-11eb-9f4f-716c9a57f828.png)

Ingame screenshots. Taken on a world with multiple mods, but the biome layers are unchanged from BOP's
![image](https://user-images.githubusercontent.com/8829856/123868844-3f496700-d8fe-11eb-82fa-83859c186583.png)
![image](https://user-images.githubusercontent.com/8829856/123868854-42dcee00-d8fe-11eb-9767-38430c38975e.png)
