### PR TITLE
Exclude Datagen class from final jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,7 @@ dependencies {
 }
 
 jar {
+    exclude "${mod_id}/common/datagen"
     manifest {
         attributes([
             'Specification-Title'     : mod_name,
@@ -88,6 +89,7 @@ jar {
 }
 
 task deobfJar(type: Jar) {
+    exclude "${mod_id}/common/datagen"
     from sourceSets.main.output
     classifier = 'deobf'
 }


### PR DESCRIPTION
Their is a good reason for this based around the fact if you import the jar for use in a project and want to run the jar in game using modImplementation() if you run data it will crash as with this class in the jar it will try to run datagen for bop as well as the mod you are working on causing it to error out.  Also overall not needed in published jar as it isn't used by players or servers only for development of the mod itself