### PR TITLE
Fix for #2161, Blood & Liquid Null

### DIFF
--- a/fabric/src/main/java/biomesoplenty/fabric/init/ModClientFabric.java
+++ b/fabric/src/main/java/biomesoplenty/fabric/init/ModClientFabric.java
@@ -13,7 +13,13 @@ public class ModClientFabric
 {
     public static void setup()
     {
-        FluidRenderHandlerRegistry.INSTANCE.register(BOPFluids.BLOOD, BOPFluids.FLOWING_BLOOD, new SimpleFluidRenderHandler(new ResourceLocation("biomesoplenty:block/blood_still"), new ResourceLocation("biomesoplenty:block/blood_flow")));
-        FluidRenderHandlerRegistry.INSTANCE.register(BOPFluids.LIQUID_NULL, BOPFluids.FLOWING_LIQUID_NULL, new SimpleFluidRenderHandler(new ResourceLocation("biomesoplenty:block/liquid_null_still"), new ResourceLocation("biomesoplenty:block/liquid_null_flow")));
+        FluidRenderHandlerRegistry.INSTANCE.register(BOPFluids.BLOOD, BOPFluids.FLOWING_BLOOD, new SimpleFluidRenderHandler(
+                new ResourceLocation("biomesoplenty:block/blood_still"),
+                new ResourceLocation("biomesoplenty:block/blood_flow"),
+                new ResourceLocation("biomesoplenty:textures/block/blood_underwater.png")));
+        FluidRenderHandlerRegistry.INSTANCE.register(BOPFluids.LIQUID_NULL, BOPFluids.FLOWING_LIQUID_NULL, new SimpleFluidRenderHandler(
+                new ResourceLocation("biomesoplenty:block/liquid_null_still"),
+                new ResourceLocation("biomesoplenty:block/liquid_null_flow"),
+                new ResourceLocation("biomesoplenty:textures/block/liquid_null_underwater.png")));
     }
 }

--- a/fabric/src/main/java/biomesoplenty/fabric/mixin/MixinBloodFluid.java
+++ b/fabric/src/main/java/biomesoplenty/fabric/mixin/MixinBloodFluid.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright 2024, the Glitchfiend Team.
+ * All rights reserved.
+ ******************************************************************************/
+package biomesoplenty.fabric.mixin;
+
+import biomesoplenty.api.block.BOPFluids;
+import com.mojang.blaze3d.systems.RenderSystem;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.client.Camera;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.client.renderer.FogRenderer;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.material.Fluid;
+import net.minecraft.world.level.material.FluidState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyArgs;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
+
+@Environment(EnvType.CLIENT)
+@Mixin(FogRenderer.class)
+public abstract class MixinBloodFluid
+{
+    @Shadow
+    private static float fogRed;
+
+    @Shadow
+    private static float fogGreen;
+
+    @Shadow
+    private static float fogBlue;
+
+    @ModifyArgs(method = "setupColor", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/systems/RenderSystem;clearColor(FFFF)V", remap = false))
+    private static void modifyFlogColors(Args args, Camera camera, float partialTicks, ClientLevel level, int renderDistanceChunks, float bossColorModifier)
+    {
+        BlockPos blockPos = camera.getBlockPosition();
+        FluidState fluidState = level.getFluidState(blockPos);
+        if(camera.getPosition().y > blockPos.getY() + fluidState.getHeight(level, blockPos))
+        {
+            return;
+        }
+
+        Fluid fluid = fluidState.getType();
+
+        if(BOPFluids.BLOOD.isSame(fluid))
+        {
+            fogRed = 0.407F;
+            fogGreen = 0.121F;
+            fogBlue = 0.137F;
+        }
+    }
+
+    @Inject(method = "setupFog", at = @At("HEAD"), cancellable = true)
+    private static void setupFog(Camera camera, FogRenderer.FogMode fogType, float viewDistance, boolean thickFog, float thickDelta, CallbackInfo ci)
+    {
+        Level level = Minecraft.getInstance().level;
+        BlockPos blockPos = camera.getBlockPosition();
+        FluidState fluidState = level.getFluidState(blockPos);
+        if(camera.getPosition().y >= blockPos.getY() + fluidState.getHeight(level, blockPos))
+        {
+            return;
+        }
+
+        Fluid fluid = fluidState.getType();
+
+        if(BOPFluids.BLOOD.isSame(fluid))
+        {
+            RenderSystem.setShaderFogStart(0.125F);
+            RenderSystem.setShaderFogEnd(5.0F);
+        }
+    }
+}

--- a/fabric/src/main/java/biomesoplenty/fabric/mixin/MixinLiquidNullFluid.java
+++ b/fabric/src/main/java/biomesoplenty/fabric/mixin/MixinLiquidNullFluid.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright 2024, the Glitchfiend Team.
+ * All rights reserved.
+ ******************************************************************************/
+package biomesoplenty.fabric.mixin;
+
+import biomesoplenty.api.block.BOPFluids;
+import com.mojang.blaze3d.systems.RenderSystem;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.client.Camera;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.client.renderer.FogRenderer;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.material.Fluid;
+import net.minecraft.world.level.material.FluidState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyArgs;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
+
+@Environment(EnvType.CLIENT)
+@Mixin(FogRenderer.class)
+public abstract class MixinLiquidNullFluid
+{
+    @Shadow
+    private static float fogRed;
+
+    @Shadow
+    private static float fogGreen;
+
+    @Shadow
+    private static float fogBlue;
+
+    @ModifyArgs(method = "setupColor", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/systems/RenderSystem;clearColor(FFFF)V", remap = false))
+    private static void modifyFlogColors(Args args, Camera camera, float partialTicks, ClientLevel level, int renderDistanceChunks, float bossColorModifier)
+    {
+        BlockPos blockPos = camera.getBlockPosition();
+        FluidState fluidState = level.getFluidState(blockPos);
+        if(camera.getPosition().y > blockPos.getY() + fluidState.getHeight(level, blockPos))
+        {
+            return;
+        }
+
+        Fluid fluid = fluidState.getType();
+
+        if(BOPFluids.LIQUID_NULL.isSame(fluid))
+        {
+            fogRed = 0.0F;
+            fogGreen = 0.0F;
+            fogBlue = 0.0F;
+        }
+    }
+
+    @Inject(method = "setupFog", at = @At("HEAD"), cancellable = true)
+    private static void setupFog(Camera camera, FogRenderer.FogMode fogType, float viewDistance, boolean thickFog, float thickDelta, CallbackInfo ci)
+    {
+        Level level = Minecraft.getInstance().level;
+        BlockPos blockPos = camera.getBlockPosition();
+        FluidState fluidState = level.getFluidState(blockPos);
+        if(camera.getPosition().y >= blockPos.getY() + fluidState.getHeight(level, blockPos))
+        {
+            return;
+        }
+
+        Fluid fluid = fluidState.getType();
+
+        if(BOPFluids.LIQUID_NULL.isSame(fluid))
+        {
+            RenderSystem.setShaderFogStart(0.1F);
+            RenderSystem.setShaderFogEnd(2.5F);
+        }
+    }
+
+}
+

--- a/fabric/src/main/resources/biomesoplenty.fabric.mixins.json
+++ b/fabric/src/main/resources/biomesoplenty.fabric.mixins.json
@@ -4,6 +4,8 @@
   "compatibilityLevel": "JAVA_17",
   "refmap": "biomesoplenty.refmap.json",
   "mixins": [
+    "MixinBloodFluid",
+    "MixinLiquidNullFluid"
   ],
   "client": [
   ],


### PR DESCRIPTION
Potential solution for this issue based off of simplified mixin logic from [the Create Mod](https://github.com/Fabricators-of-Create/Porting-Lib/blob/1.20.1/base/src/main/java/io/github/fabricators_of_create/porting_lib/mixin/client/FogRendererMixin.java#L39)'s implementation. Uses mixins to override fog logic for both the Blood & Liquid Null fluids.