### PR TITLE
Don't include night-config and typetools in fabric jar

### DIFF
--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -14,11 +14,9 @@ dependencies {
     modImplementation "com.github.glitchfiend:GlitchCore-fabric:${minecraft_version}-${glitchcore_version}"
     modImplementation "com.github.glitchfiend:TerraBlender-fabric:${minecraft_version}-${terrablender_version}"
     implementation group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.2'
-
-    // Dependencies embedded in final jar
-    include implementation("com.electronwill.night-config:toml:${nightconfig_version}")
-    include implementation("com.electronwill.night-config:core:${nightconfig_version}")
-    include implementation("net.jodah:typetools:0.6.3")
+    compileOnly("com.electronwill.night-config:toml:${nightconfig_version}")
+    compileOnly("com.electronwill.night-config:core:${nightconfig_version}")
+    compileOnly("net.jodah:typetools:0.6.3")
 }
 
 loom {


### PR DESCRIPTION
These are included in Glitch-Core and thus are not needed in the bop fabric jar as they will be present since glitchcore is required, night-config is also included in terrablender as well.