### PR TITLE
Add 1.21.1 Support for fabric

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -30,7 +30,7 @@
   "depends": {
     "fabricloader": "*",
     "fabric": "*",
-    "minecraft": "${minecraft_version}",
+    "minecraft": ">=${minecraft_version}",
     "java": ">=17",
     "glitchcore": ">=${glitchcore_version}",
     "terrablender": ">=${terrablender_version}"


### PR DESCRIPTION
In the latest version of the mod fabric displays an error saying that the mod is only for 1.21, without changing the version it is possible to launch the mod in 1.21.1 by adding a “>=” in the fabric.mod.json.