### PR TITLE
Fix hanging sign block validation. (Fix #2268)

### DIFF
--- a/common/src/main/java/biomesoplenty/block/HangingSignBlockEntityBOP.java
+++ b/common/src/main/java/biomesoplenty/block/HangingSignBlockEntityBOP.java
@@ -9,17 +9,20 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.entity.HangingSignBlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.NotNull;
 
-public class HangingSignBlockEntityBOP extends HangingSignBlockEntity
-{
-    public HangingSignBlockEntityBOP(BlockPos pos, BlockState state)
-    {
+public class HangingSignBlockEntityBOP extends HangingSignBlockEntity {
+    public HangingSignBlockEntityBOP(BlockPos pos, BlockState state) {
         super(pos, state);
     }
 
     @Override
-    public BlockEntityType<?> getType()
-    {
+    public @NotNull BlockEntityType<?> getType() {
         return BOPBlockEntities.HANGING_SIGN;
+    }
+
+    @Override
+    public boolean isValidBlockState(@NotNull BlockState state) {
+        return getType().isValid(state);
     }
 }


### PR DESCRIPTION
Minecraft added a BlockEntity validation after 1.21.1.  
It also needs to pick to the versions above it.