### PR TITLE
Add toggle for high grass movement slowdown

### DIFF
--- a/common/src/main/java/biomesoplenty/block/HighGrassPlantBlock.java
+++ b/common/src/main/java/biomesoplenty/block/HighGrassPlantBlock.java
@@ -5,6 +5,7 @@
 package biomesoplenty.block;
 
 import biomesoplenty.api.block.BOPBlocks;
+import biomesoplenty.init.ModConfig;
 import com.mojang.serialization.MapCodec;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -58,6 +59,9 @@ public class HighGrassPlantBlock extends GrowingPlantBodyBlock
     @Override
     protected void entityInside(BlockState state, Level level, BlockPos pos, Entity entity, InsideBlockEffectApplier effectApplier, boolean b)
     {
-        entity.setDeltaMovement(entity.getDeltaMovement().multiply(0.8D, 1.0D, 0.8D));
+        if (ModConfig.gameplay.highGrassPlantSlowerMovement)
+        {
+            entity.setDeltaMovement(entity.getDeltaMovement().multiply(0.8D, 1.0D, 0.8D));
+        }
     }
 }

--- a/common/src/main/java/biomesoplenty/config/GameplayConfig.java
+++ b/common/src/main/java/biomesoplenty/config/GameplayConfig.java
@@ -11,6 +11,7 @@ import glitchcore.util.Environment;
 public class GameplayConfig extends Config
 {
     public boolean wanderingTraderTrades;
+    public boolean highGrassPlantSlowerMovement;
 
     public GameplayConfig()
     {
@@ -21,5 +22,6 @@ public class GameplayConfig extends Config
     public void load()
     {
         wanderingTraderTrades = add("general.wandering_trader_trades", true, "Add various BOP resources to the Wandering Trader trade pool.");
+        highGrassPlantSlowerMovement = add("blocks.high_grass_plant_slower_movement", true, "Slow down player when inside high grass plant block.");
     }
 }


### PR DESCRIPTION
While the slower movement through high grass adds to the immersion, some players may find the mechanic tedious.

A new option was added to `gameplay.toml` as follows:
- **Key:** `blocks.high_grass_plant_slower_movement`;
- **Default:** `true` (preserves original mod behavior).

Relates to #2365.