### PR TITLE
Crash fix for #2443: Anomaly block rendering

### DIFF
--- a/common/src/main/java/biomesoplenty/client/renderer/AnomalyRenderer.java
+++ b/common/src/main/java/biomesoplenty/client/renderer/AnomalyRenderer.java
@@ -43,7 +43,7 @@ public class AnomalyRenderer implements BlockEntityRenderer<AnomalyBlockEntity, 
     public void extractRenderState(AnomalyBlockEntity blockEntity, AnomalyRenderState renderState, float $$2, Vec3 $$3, @Nullable ModelFeatureRenderer.CrumblingOverlay $$4)
     {
         BlockEntityRenderState.extractBase(blockEntity, renderState, $$4);
-        renderState.state = blockEntity.getRenderState();
+        renderState.state = blockEntity.getBlockState();
         this.blockModelResolver.update(renderState.anomalyRenderState, blockEntity.getRenderState(), BLOCK_DISPLAY_CONTEXT);
     }
 


### PR DESCRIPTION
There is a check to skip block entity rendering if the Anomaly block's `AnomalyBlock.ANOMALY_TYPE` block property is `STABLE`.
However, `blockEntity.getRenderState()` is stored in the render state during extraction, so the game tries to get the block property for a random vanilla block, not for the block itself.
**This causes the game to crash.**

Replacing the call with `blockEntity.getBlockState()` seems to fix the issue.
`blockEntity.getRenderState()` is still called for updating the `blockModelResolver` and actually rendering the anomaly, so existing functionality is unaffected.

Also, the crash was introduced in [commit ffdd4e1](https://github.com/Glitchfiend/BiomesOPlenty/commit/ffdd4e1d6b67265bb4247a7fe64b6761d77ee198), so it only affects Minecraft 26.1.